### PR TITLE
ofdpa: do not unconditionally enable dropping of non unicast

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r3"
 SDK_VERSION = "6.5.22"
-SRCREV_ofdpa = "bb9db50f376d2cc2e47234e587505b64968ec349"
+SRCREV_ofdpa = "8a370b491aa5731de3287805879614569f06085a"
 SRCREV_sdk = "f01ceb9cf4238b762cc4422e7ebe1c38a113464e"
 
 DEPENDS = "python3 onl"


### PR DESCRIPTION
OF-DPA disabled by default forwarding of non unicast packets in VLANs
(i.e. broad- and multicast), and only selectively enables it when
creating a bridging flow that targets a flood group or a L2 multicast
group.

This is mostly fine, except when removing a bridging flow that targets a
L2 multicast group, OF-DPA will unconditionally disable forwarding
again, potentially breaking any existing flood flows.

Similarily, removing a briding flow will leave forwarding enabled,
regardless of other flows being present or not.

To fix this, add a function for counting the amount of flows enabling
broad- and multicast forwarding, and only disable it if there are none
left.

Fixes enabling multicast breaking DHCP.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>