### PR TITLE
switch to release 4.1 binaries and add checksums

### DIFF
--- a/recipes-extended/ofdpa-grpc/ofdpa-grpc_git.bb
+++ b/recipes-extended/ofdpa-grpc/ofdpa-grpc_git.bb
@@ -1,11 +1,14 @@
 LICENSE = "CLOSED"
 
 # Nightly packages are regenerated regularily
-BB_STRICT_CHECKSUM = "0"
+BB_STRICT_CHECKSUM = "1"
 
 SRC_URI = " \
- http://repo.bisdn.de/nightly_builds/${MACHINE}/master/packages_latest-build/ipk/${PACKAGE_ARCH}/${BPN}_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
+ http://repo.bisdn.de/pub/onie/${MACHINE}/packages-v${DISTRO_VERSION}/ipk/${PACKAGE_ARCH}/${BPN}_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P};;sha256sum=${@d.getVarFlag('SHA256SUM', '${PACKAGE_ARCH}', 1)} \
 "
+
+SHA256SUM[cortexa9-vfp] = "9578f89c0277cad0b2ef1a73d1db4a2d76a88cf624e4ce6b922ff0f5205230bd"
+SHA256SUM[corei7-64] = "7f540d4289944ea324c8218c6537200449ececef80f9906607156fb8b772b475"
 
 # Manually calculate expanded ${SRCPV} value
 PV = "0.3+gitAUTOINC+${@'${SRCREV}'[0:10]}"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -15,14 +15,34 @@ RDEPENDS_${PN} += "libgcc udev openbcm-gpl-modules"
 RDEPENDS_${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56770', '${PN}-firmware-bcm56770', '', d)}"
 
 # Nightly packages are regenerated regularily
-BB_STRICT_CHECKSUM = "0"
+BB_STRICT_CHECKSUM = "1"
 
 SRC_URI = " \
- http://repo.bisdn.de/nightly_builds/${MACHINE}/master/packages_latest-build/ipk/${MACHINE_ARCH}/ofagent_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
- http://repo.bisdn.de/nightly_builds/${MACHINE}/master/packages_latest-build/ipk/${MACHINE_ARCH}/ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
- http://repo.bisdn.de/nightly_builds/${MACHINE}/master/packages_latest-build/ipk/${MACHINE_ARCH}/ofdpa-firmware-bcm56770_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
- http://repo.bisdn.de/nightly_builds/${MACHINE}/master/packages_latest-build/ipk/${MACHINE_ARCH}/python3-ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
+ http://repo.bisdn.de/pub/onie/${MACHINE}/packages-v${DISTRO_VERSION}/ipk/${MACHINE_ARCH}/ofagent_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P};sha256sum=${@d.getVarFlag('SHA256SUMS', '${MACHINE}.ofagent', 1)} \
+ http://repo.bisdn.de/pub/onie/${MACHINE}/packages-v${DISTRO_VERSION}/ipk/${MACHINE_ARCH}/ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P};sha256sum=${@d.getVarFlag('SHA256SUMS', '${MACHINE}.ofdpa', 1)} \
+ http://repo.bisdn.de/pub/onie/${MACHINE}/packages-v${DISTRO_VERSION}/ipk/${MACHINE_ARCH}/ofdpa-firmware-bcm56770_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P};sha256sum=${@d.getVarFlag('SHA256SUMS', '${MACHINE}.ofdpa-firmware-bcm56770', 1)} \
+ http://repo.bisdn.de/pub/onie/${MACHINE}/packages-v${DISTRO_VERSION}/ipk/${MACHINE_ARCH}/python3-ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P};sha256sum=${@d.getVarFlag('SHA256SUMS', '${MACHINE}.python3-ofdpa', 1)} \
 "
+
+SHA256SUMS[accton-as4610.ofagent] = "d7f8c976365c12b0821d658725edb87c39c09294d705fdadc482c2d7b981e86d"
+SHA256SUMS[accton-as4610.ofdpa] = "1a03b575eda3ec88cd0a9fe313c7b135c74716ee5b931fa8f80d036447b0fe07"
+SHA256SUMS[accton-as4610.ofdpa-firmware-bcm56770] = "ff31d4865188a05b02a3e5a51f413efe242d553469d830903e81b72cfb3c0099"
+SHA256SUMS[accton-as4610.python3-ofdpa] = "8347ff7426455d42783cf48ffe2d14c7725d8ba59ab4ede26d17d87d777c723c"
+
+SHA256SUMS[agema-ag5648.ofagent] = "b4a21f469589aa7d6b9ec6d774f0331449155c61411e6937c25bba3288113f1c"
+SHA256SUMS[agema-ag5648.ofdpa] = "9e456e155d05d295e0e29d53ee401d126dd781304f77e95be3ece4c0ccc38dd4"
+SHA256SUMS[agema-ag5648.ofdpa-firmware-bcm56770] = "382421f9c2cb78f34feb8cfae17fbac6d629fd24e0f413dceeed77d81ca00978"
+SHA256SUMS[agema-ag5648.python3-ofdpa] = "459f931f959d6716c2f91fc9c2122a6acd573b66dc5521c3887f371ea5e6d95a"
+
+SHA256SUMS[agema-ag7648.ofagent] = "9b80832d73074724ae3c25594c5021ffd8d27c23dccb9818cfec7f02634bcb3b"
+SHA256SUMS[agema-ag7648.ofdpa] = "3c8ab34b767c45378e890e34b5e7e6cae8e9b8a52f0961f692a585922cd214f1"
+SHA256SUMS[agema-ag7648.ofdpa-firmware-bcm56770] = "929cdfe3e10a5c1913cf8b33f7b82be26d31b944dfe8433da066dcb2951272ae"
+SHA256SUMS[agema-ag7648.python3-ofdpa] = "765700b380e353026cc18eed165f90e67dd2d5544355c28f8115418effe9d9e4"
+
+SHA256SUMS[cel-questone-2a.ofagent] = "5d43be3b01a2ef21eda2c81360b07e5f41a95a95e3c6919ac3b70997bfb71b0c"
+SHA256SUMS[cel-questone-2a.ofdpa] = "b5d1bf144f82e3129deac2c6059c84e988dc6db59d6aa67da7ed7e8f54c6db62"
+SHA256SUMS[cel-questone-2a.ofdpa-firmware-bcm56770] = "301ade3b49019a68fc8d05f69ebe4091a5c819167e6f4446d6c8c49b422239f7"
+SHA256SUMS[cel-questone-2a.python3-ofdpa] = "68b7c210bc29ed8522f87834ee8ea61cac57d11f1be2c869d1c3e5b7c54d65e9"
 
 inherit bin_package systemd python3-dir
 


### PR DESCRIPTION
Update the SRC_URIs for ofdpa and ofdpa-grpc to point to the v4.1.0 release and add appropriate checksums for all packages.

ofdpa-grpc checksums are identical to 4.0.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>