### PR TITLE
ofdpa: make build reproducable by following SOURCE_DATE_EPOCH

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r3"
 SDK_VERSION = "6.5.22"
-SRCREV_ofdpa = "8a370b491aa5731de3287805879614569f06085a"
+SRCREV_ofdpa = "ce97ed9907a369c08774f724587f73c2f6039ab1"
 SRCREV_sdk = "f01ceb9cf4238b762cc4422e7ebe1c38a113464e"
 
 DEPENDS = "python3 onl"


### PR DESCRIPTION
Replace all instances off scripts or code extracting the current time
with a check for the environment variable SOURCE_DATE_EPOCH and using
its value instead if set.

This makes the build reproducable, as Yocto will set the
SOURCE_DATE_EPOCH to the top commit's commit date of the OF-DPA
repository.

This will make the resulting opkg package reproducable, which in turn
allows us to have checksums in the open source repository.

To verify that the build is reproducable:

 $ bitbake ofdpa
 $ sha256sum /tmp/deploy/ipk/.../ofdpa_*.ipk
 $ bitbake -c cleansstate ofdpa
 $ bitbake ofdpa
 $ sha256sum /tmp/deploy/ipk/.../ofdpa_*.ipk

The SHA256 checksum will now be identical.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>