### PR TITLE
ofdpa: add support for Accton AS7726-32X

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # Include SDK version, and OF-DPA and OpenBCM source revisions in version
 PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'${SRCREV_sdk}'[:10]}"
 
-PR = "r3"
+PR = "r4"
 SDK_VERSION = "6.5.22"
 SRCREV_ofdpa = "ce97ed9907a369c08774f724587f73c2f6039ab1"
 SRCREV_sdk = "f01ceb9cf4238b762cc4422e7ebe1c38a113464e"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -21,6 +21,7 @@ SRC_URI = " \
  http://repo.bisdn.de/nightly_builds/${MACHINE}/master/packages_latest-build/ipk/${MACHINE_ARCH}/ofagent_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
  http://repo.bisdn.de/nightly_builds/${MACHINE}/master/packages_latest-build/ipk/${MACHINE_ARCH}/ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
  http://repo.bisdn.de/nightly_builds/${MACHINE}/master/packages_latest-build/ipk/${MACHINE_ARCH}/ofdpa-firmware-bcm56770_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
+ http://repo.bisdn.de/nightly_builds/${MACHINE}/master/packages_latest-build/ipk/${MACHINE_ARCH}/ofdpa-firmware-bcm56870_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
  http://repo.bisdn.de/nightly_builds/${MACHINE}/master/packages_latest-build/ipk/${MACHINE_ARCH}/python3-ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
 "
 
@@ -54,7 +55,7 @@ INHIBIT_PACKAGE_DEBUG_SPLIT  = "1"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PACKAGES =+ "ofagent python3-${PN} ${PN}-firmware-bcm56770"
+PACKAGES =+ "ofagent python3-${PN} ${PN}-firmware-bcm56770 ${PN}-firmware-bcm56870"
 
 FILES_${PN} += "\
             ${sbindir}/ofdpa \
@@ -75,6 +76,10 @@ FILES_python3-${PN} = " \
                       "
 FILES_${PN}-firmware-bcm56770 = " \
            ${nonarch_base_libdir}/firmware/brcm/bcm56770*.pkg \
+           "
+
+FILES_${PN}-firmware-bcm56870 = " \
+           ${nonarch_base_libdir}/firmware/brcm/bcm56870*.pkg \
            "
 
 CONFFILES_${PN} = " \


### PR DESCRIPTION
Add support for Accton AS7726-32X. This is a 32x100G platform, with two additional 10G ports.

This is mostly a standard Trident-3 X7 platform, so it is fairly easy to support. We mostly need to package up the appropriate firmware files as a new package.

The most interesting thing are two 10G ports, that are connected to a multiplexer, which can be switched between the SFP+ ports, and the internal 10G macs of the Intel SoC.

Currently we do not provide a way of using the internal connection, so we assume these are connected to the 10G ports and are regular SFP+ ports.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>