### PR TITLE
conf: drop warrior compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,4 +14,4 @@ LAYERVERSION_ofdpa    = "1"
 # LAYERDEPENDS_sdn    = "acceleration"
 # LAYERDEPENDS_ofdpa    = "openembedded-layer"
 
-LAYERSERIES_COMPAT_ofdpa = "warrior dunfell"
+LAYERSERIES_COMPAT_ofdpa = "dunfell"


### PR DESCRIPTION
Warrior is old, and now untested for quite a while, so let's drop
compatibility with it.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>