### PR TITLE
ofdpa: accton-as4610: fix LED blink on activity

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # Include SDK version, and OF-DPA and OpenBCM source revisions in version
 PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'${SRCREV_sdk}'[:10]}"
 
-PR = "r4"
+PR = "r5"
 SDK_VERSION = "6.5.22"
 SRCREV_ofdpa = "ce97ed9907a369c08774f724587f73c2f6039ab1"
 SRCREV_sdk = "f01ceb9cf4238b762cc4422e7ebe1c38a113464e"


### PR DESCRIPTION
Looks like activity (0x3) is not the mode we want, but multicolor (0xa).

Luckily guessed based on values from

https://elixir.bootlin.com/linux/v5.14.12/source/include/linux/brcmphy.h#L140

to maybe use BCM_LED_SRC_MULTICOLOR1, expecting it to default to
BCM_LED_MULTICOLOR_LINK_ACT, which is what we want.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>