### PR TITLE
ofdpa: treat AS4610-54T (B) as AS4610-54T

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # Include SDK version, and OF-DPA and OpenBCM source revisions in version
 PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'${SRCREV_sdk}'[:10]}"
 
-PR = "r5"
+PR = "r6"
 SDK_VERSION = "6.5.22"
 SRCREV_ofdpa = "ce97ed9907a369c08774f724587f73c2f6039ab1"
 SRCREV_sdk = "f01ceb9cf4238b762cc4422e7ebe1c38a113464e"


### PR DESCRIPTION
None of the differences are relevant to OF-DPA, so treat AS4610-54T (B)
the same as AS4610-54T.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>