### PR TITLE
update ofdpa to latest version

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r6"
 SDK_VERSION = "6.5.22"
-SRCREV_ofdpa = "c599213448ffe922826db3782495ed21a2082435"
+SRCREV_ofdpa = "e67b2bae86c8c8ea5b06170af4b539803faf2b3b"
 SRCREV_sdk = "f01ceb9cf4238b762cc4422e7ebe1c38a113464e"
 
 DEPENDS = "python3 onl"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r6"
 SDK_VERSION = "6.5.22"
-SRCREV_ofdpa = "ce97ed9907a369c08774f724587f73c2f6039ab1"
+SRCREV_ofdpa = "c599213448ffe922826db3782495ed21a2082435"
 SRCREV_sdk = "f01ceb9cf4238b762cc4422e7ebe1c38a113464e"
 
 DEPENDS = "python3 onl"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r6"
 SDK_VERSION = "6.5.22"
-SRCREV_ofdpa = "e67b2bae86c8c8ea5b06170af4b539803faf2b3b"
+SRCREV_ofdpa = "a1b1e04908432e7ec42827febcd91ab9f9519127"
 SRCREV_sdk = "f01ceb9cf4238b762cc4422e7ebe1c38a113464e"
 
 DEPENDS = "python3 onl"


### PR DESCRIPTION
Update OF-DPA with the latest changes:

* ofdpa_pktrxtx: fix output and error handling
* ofdpa: fix mplsL2Port and tunnelId formatting for client_flowtable_dump 
* ofdpa: propagate learning mode also to l2 station move

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>