### PR TITLE
ofdpa: prevent unprivileged access to the bcm diag shell

### DIFF
--- a/recipes-extended/ofdpa-grpc/ofdpa-grpc_git.bb
+++ b/recipes-extended/ofdpa-grpc/ofdpa-grpc_git.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
 
 # Manually calculate expanded ${SRCPV} value
 PV = "0.3+gitAUTOINC+${@'${SRCREV}'[0:10]}"
-SRCREV = "c8281e4cd6c62e653e4c21963b3e27d8e228f33f"
+SRCREV = "3449f76800dd89fd3040dcacac720876b720fab5"
 
 DEPENDS = "grpc gflags glog protobuf openssl ofdpa"
 

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,9 +4,9 @@ LICENSE = "CLOSED"
 # Include SDK version, and OF-DPA and OpenBCM source revisions in version
 PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'${SRCREV_sdk}'[:10]}"
 
-PR = "r7"
+PR = "r8"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "a1b1e04908432e7ec42827febcd91ab9f9519127"
+SRCREV_ofdpa = "c2d7f9f3af8730338d4e7b8936e27991f94778a4"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 DEPENDS = "python3 onl"


### PR DESCRIPTION
Harden OF-DPA and ofdpa-grpc against unprivileged accesses to the bcm diag shell:

* require root for accessing the server's unix socket (and thus the server directly)
* verify stp states are valid state names in ofdpa-grpc

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>