### PR TITLE
v4.3.1: backport fixes

### DIFF
--- a/recipes-extended/ofdpa-grpc/ofdpa-grpc_git.bb
+++ b/recipes-extended/ofdpa-grpc/ofdpa-grpc_git.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
 
 # Manually calculate expanded ${SRCPV} value
 PV = "0.3+gitAUTOINC+${@'${SRCREV}'[0:10]}"
-SRCREV = "c8281e4cd6c62e653e4c21963b3e27d8e228f33f"
+SRCREV = "3449f76800dd89fd3040dcacac720876b720fab5"
 
 DEPENDS = "grpc gflags glog protobuf openssl ofdpa"
 

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,9 +4,9 @@ LICENSE = "CLOSED"
 # Include SDK version, and OF-DPA and OpenBCM source revisions in version
 PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'${SRCREV_sdk}'[:10]}"
 
-PR = "r6"
+PR = "r6.1"
 SDK_VERSION = "6.5.22"
-SRCREV_ofdpa = "a1b1e04908432e7ec42827febcd91ab9f9519127"
+SRCREV_ofdpa = "c2d7f9f3af8730338d4e7b8936e27991f94778a4"
 SRCREV_sdk = "f01ceb9cf4238b762cc4422e7ebe1c38a113464e"
 
 DEPENDS = "python3 onl"


### PR DESCRIPTION
Backport two fixes in preparation for the v4.3.1 release.

Bump the OF-DPA version to just 6.1 to signify that this is r6 with one extra change.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>