### PR TITLE
ofdpa updates: l2/l3 memory allocation mode; bcm.log

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r12"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "1a21a1e29c5a3d21b2d26278b45c8c1b022cf014"
+SRCREV_ofdpa = "d3398e8dfa50948b9985fe289ba550baaf2732c6"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 DEPENDS = "python3 onl"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r12"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "257900c53522a220713e5fd2fe752f058ee8e769"
+SRCREV_ofdpa = "65302857188a55cf23fb8bbb72dc592baaa9c5c6"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 DEPENDS = "python3 onl"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r12"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "1cd775fc257dcfb382113c834c64597d52eafc5a"
+SRCREV_ofdpa = "1a21a1e29c5a3d21b2d26278b45c8c1b022cf014"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 DEPENDS = "python3 onl"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r12"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "d3398e8dfa50948b9985fe289ba550baaf2732c6"
+SRCREV_ofdpa = "257900c53522a220713e5fd2fe752f058ee8e769"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 DEPENDS = "python3 onl"


### PR DESCRIPTION
This PR contains a number of fixes and extensions for ofdpa, including:

* allow setting l2/l3 memory allocation mode
* move bcm.log from /usr/sbin to /var/log 