### PR TITLE
ofdpa: fix issues found during collection of table sizes

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r13"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "65302857188a55cf23fb8bbb72dc592baaa9c5c6"
+SRCREV_ofdpa = "56203d8d3f6c3d6805bbe43762394c75818e27ce"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 DEPENDS = "python3 onl"


### PR DESCRIPTION
Fix two issues found while collecting resulting table sizes:

Trident 2(+) only supports assigning up to 3 memory banks to L3, trying
to assign all of them will cause SDK to fail initialization:

Apr 27 09:45:27 agema-ag7648 ofdpa[3683]: The specified l3_mem_entries (278528) exceeds 208K

Fix this by reserving one bank for L2 when using the MAX_L3 alloc mode.

Trident 3 X3 (Helix 5) models other than BCM56370 were not recognized as
supported, causing the code to not do anything on e.g. EPS202
(AS4630-54PE).

Fixes: 8af944e ("ofdpa: allow setting l2/l3 memory allocation mode")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
Signed-off-by: hilmar.magnusson <hilmar.magnusson@bisdn.de>