### PR TITLE
ofdpa: Add two commits from internal repos

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r13"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "65302857188a55cf23fb8bbb72dc592baaa9c5c6"
+SRCREV_ofdpa = "f907df87ba6d0a0058ff4daab74694883dc264d2"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 DEPENDS = "python3 onl"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PV = "3.0.5.0-EA5+sdk-${SDK_VERSION}+gitAUTOINC+${@'${SRCREV_ofdpa}'[:10]}_${@'$
 
 PR = "r13"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "f907df87ba6d0a0058ff4daab74694883dc264d2"
+SRCREV_ofdpa = "56203d8d3f6c3d6805bbe43762394c75818e27ce"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 DEPENDS = "python3 onl"


### PR DESCRIPTION
Adding two commits from internal meta-ofdpa repos:

- ofdpa: do not disable platforms manually
- ofdpa: fix issues found during collection of table sizes

See individual commits for more information on what they do
