### PR TITLE
ofdpa: add missing RDEPENDS for Trident 3 X7 firmware

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -14,6 +14,7 @@ RDEPENDS_${PN} += "libgcc udev openbcm-gpl-modules"
 
 RDEPENDS_${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56370', '${PN}-firmware-bcm56370', '', d)}"
 RDEPENDS_${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56770', '${PN}-firmware-bcm56770', '', d)}"
+RDEPENDS_${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56870', '${PN}-firmware-bcm56870', '', d)}"
 
 # Nightly packages are regenerated regularily
 BB_STRICT_CHECKSUM = "0"


### PR DESCRIPTION
Add missing RDEPENDS for Trident 3 X7 files, which was accidentally
dropped when adding the required changes into the public repo.

Fixes: cef9203a5851 ("ofdpa: package Trident 3 X7 firmware files")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>