### PR TITLE
ofdpa: accton-as4630-54pe: fix programming SFP leds

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r13"
+PR = "r14"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "56203d8d3f6c3d6805bbe43762394c75818e27ce"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r15"
+PR = "r16"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "56203d8d3f6c3d6805bbe43762394c75818e27ce"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r14"
+PR = "r15"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "56203d8d3f6c3d6805bbe43762394c75818e27ce"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"


### PR DESCRIPTION
Newer Trident 3 based accton switches use a slightly modified LED data
format, a mix of the old and new formats where the speed is shifted by 1
to make room for the link status.
To properly support it, add a new configuration option
spn_CMCX_LED_ACCTION_DATA to enable this format during runtime, and enable
it for Accton AS4630-54PE.
Fixes setting (Q)SFP status leds with their correct states.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>