### PR TITLE
convert layer to kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,4 +14,4 @@ LAYERVERSION_ofdpa    = "1"
 # LAYERDEPENDS_sdn    = "acceleration"
 # LAYERDEPENDS_ofdpa    = "openembedded-layer"
 
-LAYERSERIES_COMPAT_ofdpa = "dunfell"
+LAYERSERIES_COMPAT_ofdpa = "kirkstone"

--- a/recipes-extended/man-pages/man-pages_%.bbappend
+++ b/recipes-extended/man-pages/man-pages_%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
   file://client_cfg_purge.1 \
@@ -15,7 +15,7 @@ SRC_URI += " \
   file://client_tunnel_dump.1 \
 "
 
-do_install_append() {
+do_install:append() {
   install -g 0 -o 0 -m 0644 ${WORKDIR}/client_*.1 ${D}${datadir}/man/man1/
   gzip ${D}${datadir}/man/man1/client_*.1
 }

--- a/recipes-extended/ofdpa-grpc/ofdpa-grpc_git.bb
+++ b/recipes-extended/ofdpa-grpc/ofdpa-grpc_git.bb
@@ -20,9 +20,9 @@ inherit systemd bin_package
 # for some reason ipk doesn't trigger xz-native as a dependency
 do_unpack[depends] += " xz-native:do_populate_sysroot"
 
-SYSTEMD_SERVICE_${PN}_append = "ofdpa-grpc.service"
+SYSTEMD_SERVICE:${PN}:append = "ofdpa-grpc.service"
 
-INSANE_SKIP_${PN} = "ldflags"
+INSANE_SKIP:${PN} = "ldflags"
 
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_SYSROOT_STRIP = "1"
@@ -30,6 +30,6 @@ INHIBIT_PACKAGE_DEBUG_SPLIT  = "1"
 
 # systemd.class will append to existing presets, so remove them to avoid
 # duplicating their contents.
-do_install_append() {
+do_install:append() {
 	rm -f ${D}/lib/systemd/system-preset/*
 }

--- a/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
+++ b/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
@@ -25,19 +25,19 @@ SRC_URI = " \
           file://patches/xgs_iproc_compat.patch \
           "
 
-SRC_URI_append_agema-ag7648 = " \
+SRC_URI:append:agema-ag7648 = " \
     file://linux_kernel_bde.conf \
 "
 
 S = "${WORKDIR}/src"
 
-FILES_${PN} += "\
+FILES:${PN} += "\
             ${sbindir}/bisdn-bcm-dev.sh \
             ${sysconfdir}/udev/rules.d/bisdn-bcm-dev.rules \
             "
-FILES_${PN}_append_agema-ag7648 = "${sysconfdir}/modprobe.d/linux_kernel_bde.conf"
+FILES:${PN}:append:agema-ag7648 = "${sysconfdir}/modprobe.d/linux_kernel_bde.conf"
 
-do_install_append() {
+do_install:append() {
 	# update path marker in udev rules
 	sed -i -e "s#SBINDIR#${sbindir}#" ${WORKDIR}/bisdn-bcm-dev.rules
 
@@ -47,7 +47,7 @@ do_install_append() {
 	install -m 0644 ${WORKDIR}/bisdn-bcm-dev.rules ${D}${sysconfdir}/udev/rules.d
 }
 
-do_install_append_agema-ag7648() {
+do_install:append:agema-ag7648() {
         install -d ${D}${sysconfdir}/modprobe.d/
         install -m 0644 ${WORKDIR}/*.conf ${D}${sysconfdir}/modprobe.d/
 }

--- a/recipes-ofdpa/ofdpa/ofdpa.inc
+++ b/recipes-ofdpa/ofdpa/ofdpa.inc
@@ -26,12 +26,12 @@ deltask do_populate_lic
 
 # systemd.class will append to existing presets, so remove them to avoid
 # duplicating their contents.
-do_install_append() {
+do_install:append() {
 	rm -f ${D}/lib/systemd/system-preset/*
 }
 
-INSANE_SKIP_${PN} = "ldflags"
-INSANE_SKIP_ofagent = "ldflags"
+INSANE_SKIP:${PN} = "ldflags"
+INSANE_SKIP:ofagent = "ldflags"
 
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_SYSROOT_STRIP = "1"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -15,18 +15,18 @@ include ofdpa.inc
 
 DEPENDS += "python3 onl"
 
-RDEPENDS_${PN} += "libgcc udev openbcm-gpl-modules"
+RDEPENDS:${PN} += "libgcc udev openbcm-gpl-modules"
 
-RDEPENDS_${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56370', '${PN}-firmware-bcm56370', '', d)}"
-RDEPENDS_${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56770', '${PN}-firmware-bcm56770', '', d)}"
-RDEPENDS_${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56870', '${PN}-firmware-bcm56870', '', d)}"
+RDEPENDS:${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56370', '${PN}-firmware-bcm56370', '', d)}"
+RDEPENDS:${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56770', '${PN}-firmware-bcm56770', '', d)}"
+RDEPENDS:${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56870', '${PN}-firmware-bcm56870', '', d)}"
 
 SYSTEMD_PACKAGES = "${PN} ofagent"
-SYSTEMD_SERVICE_${PN} = "ofdpa.service"
-SYSTEMD_SERVICE_ofagent = "ofagent.service"
+SYSTEMD_SERVICE:${PN} = "ofdpa.service"
+SYSTEMD_SERVICE:ofagent = "ofagent.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
-INSANE_SKIP_python3-${PN} = "ldflags"
+INSANE_SKIP:python3-${PN} = "ldflags"
 
 PACKAGES =+ "\
              ofagent \
@@ -36,7 +36,7 @@ PACKAGES =+ "\
              ${PN}-firmware-bcm56870 \
              "
 
-FILES_${PN} += "\
+FILES:${PN} += "\
             ${sbindir}/ofdpa \
             ${sysconfdir}/default/ofdpa \
             ${sysconfdir}/ofdpa \
@@ -45,30 +45,30 @@ FILES_${PN} += "\
             ${libdir}/librpc_client*${SOLIBS} \
             "
 
-FILES_ofagent = "${sbindir}/ofagent \
+FILES:ofagent = "${sbindir}/ofagent \
                  ${sysconfdir}/default/ofagent \
                  ${systemd_unitdir}/system/ofagent.service"
 
-FILES_python3-${PN} = " \
+FILES:python3-${PN} = " \
                       ${PYTHON_SITEPACKAGES_DIR} \
                       ${sbindir}/ofdpa*.py \
                       "
 
-FILES_${PN}-firmware-bcm56370 = " \
+FILES:${PN}-firmware-bcm56370 = " \
             ${nonarch_base_libdir}/firmware/brcm/bcm56370*.pkg \
             "
 
-FILES_${PN}-firmware-bcm56770 = " \
+FILES:${PN}-firmware-bcm56770 = " \
             ${nonarch_base_libdir}/firmware/brcm/bcm56770*.pkg \
             "
 
-FILES_${PN}-firmware-bcm56870 = " \
+FILES:${PN}-firmware-bcm56870 = " \
             ${nonarch_base_libdir}/firmware/brcm/bcm56870*.pkg \
             "
 
-CONFFILES_${PN} = " \
+CONFFILES:${PN} = " \
   ${sysconfdir}/default/ofdpa \
   ${sysconfdir}/ofdpa/rc.soc \
 "
 
-CONFFILES_ofagent = "${sysconfdir}/default/ofagent"
+CONFFILES:ofagent = "${sysconfdir}/default/ofagent"


### PR DESCRIPTION
Convert recipes to the new override syntax using

  find meta-ofdpa | grep -e '\.bb$' -e '\.inc$' -e '\.conf$' -e '\.bbappend$' | xargs -n 1 ./scripts/contrib/convert-overrides.py

for the basic overrides (append, prepend, remove, ${ARCH}), and manually
replace the machine overrides by hand.

Finally set the layer compatibility to kirkstone.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>