### PR TITLE
openbcm-gpl-modules: fix license name

### DIFF
--- a/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
+++ b/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = " \
 	file://systems/bde/linux/user/kernel/linux-user-bde.c;endline=15;md5=ac2e812a539f3a9b3802636f1d3ef09c \
 	file://systems/bde/linux/kernel/linux-kernel-bde.c;endline=15;md5=ac2e812a539f3a9b3802636f1d3ef09c \


### PR DESCRIPTION
The correct SPDX compatible license is GPL-2.0-only, so update it.

Fixes the following warning when building when kirkstone:

```
  WARNING: openbcm-gpl-modules-6.5.24-r0 do_package_qa: QA Issue: Recipe LICENSE includes obsolete licenses GPLv2 [obsolete-license]
```

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>