### PR TITLE
ofdpa: accton-as4610: switch L7 OS to ubuntu

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r16"
+PR = "r17"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "56203d8d3f6c3d6805bbe43762394c75818e27ce"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"


### PR DESCRIPTION
brl assumes a custom broadcom linux kernel we don't have, which causes
the ebc tool to get stuck in an endless loop trying to access it.

Instead of patching around it, just pretend we are ubuntu as it does not
trigger any kernel checkout. This is also what we do for all the other
machines.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>