### PR TITLE
Revert "ofdpa: explicitly link against libonlp-platform"

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r17"
+PR = "r18"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "56203d8d3f6c3d6805bbe43762394c75818e27ce"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"


### PR DESCRIPTION
Now that the ONL package provides a libonlp-platform.so that is a
tangible library with fixed (i.e. no additional) dependencies, we can
drop the explicit link against libonlp-<platform>.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>