### PR TITLE
ofdpa: populate port MAC addresses from ONL

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 PR = "r18"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "56203d8d3f6c3d6805bbe43762394c75818e27ce"
+SRCREV_ofdpa = "24ba7ed18e0c837e2f6b363740dca499aa46af02"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
Link against libonlp and assign consecutive MAC addresses to ports based
on the MAC address stored in the ONIE EEPROM.

For those platforms with more than one preallocated MAC address from the
pool, add platform functions to retrieve the correct amount of MAC
addresses to skip (which is three for all Trident 3 based Edgecore
systems).

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>