### PR TITLE
ofdpa: as5835-54x: sort ports by user (not logical) port

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r19"
+PR = "r20"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "24ba7ed18e0c837e2f6b363740dca499aa46af02"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"


### PR DESCRIPTION
The port mapping table for the as5835 is currently sorted by logical
port (mostly). This worked fine until now. However, the newly introduced
code for setting MAC addresses receives the ports in the same order but
assumes they are sorted by the user port number (i.e., the label on the
physical ports on the switch), resulting in the 100 G ports (user ports
49 through 54) picking up MAC addresses from the middle of the range
instead of the last ones.

The result is "ip -br link" reporting something like this:

[...]
port46           DOWN           f8:8e:a1:e0:bb:47 <BROADCAST,MULTICAST>
port47           DOWN           f8:8e:a1:e0:bb:48 <BROADCAST,MULTICAST>
port48           DOWN           f8:8e:a1:e0:bb:49 <BROADCAST,MULTICAST>
port49           DOWN           f8:8e:a1:e0:bb:2e <BROADCAST,MULTICAST>
port50           DOWN           f8:8e:a1:e0:bb:2c <BROADCAST,MULTICAST>
port51           DOWN           f8:8e:a1:e0:bb:2d <BROADCAST,MULTICAST>
port52           DOWN           f8:8e:a1:e0:bb:2f <BROADCAST,MULTICAST>
port53           DOWN           f8:8e:a1:e0:bb:30 <BROADCAST,MULTICAST>
port54           DOWN           f8:8e:a1:e0:bb:31 <BROADCAST,MULTICAST>

This change moves the 100 G ports to the end of the table and removes
the now rather confusing comments on gaps in the series of logical ports.