### PR TITLE
ofdpa: split rc.soc into user and system files

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,9 +4,9 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r20"
+PR = "r21"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "24ba7ed18e0c837e2f6b363740dca499aa46af02"
+SRCREV_ofdpa = "23025dc2048802924973b17748ef04625158c01c"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir
@@ -43,6 +43,7 @@ FILES:${PN} += "\
             ${systemd_unitdir}/system/ofdpa.service \
             ${sbindir}/client* \
             ${libdir}/librpc_client*${SOLIBS} \
+            ${datadir}/ofdpa/rc.soc \
             "
 
 FILES:ofagent = "${sbindir}/ofagent \

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 PR = "r21"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "23025dc2048802924973b17748ef04625158c01c"
+SRCREV_ofdpa = "7f83aa6ce52f1909cd0bc604e5218c3ce2c6597d"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
Split the rc.soc into a system rc.soc at /usr/share/ofdpa/, and a user
rc.soc at the old location at /etc/ofdpa/rc.soc.

This way we have a rc.soc we can update, while maintaining the user
settings on upgrade.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>