### PR TITLE
ofpda: split up values in /etc/ofdpa/default and use balanced l2l3 mode

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r21"
+PR = "r23"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "7f83aa6ce52f1909cd0bc604e5218c3ce2c6597d"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"


### PR DESCRIPTION
Switch the L2L3 mode to balanced in the config, as it will give at least the same table sizes, and actually increases them on some platforms.

To make it easier to change one without the other, create separate variables for debug options and l2l3 mode. To still support migrated option sysconf files, also allow OPTIONS, but do not set it as a value in the sysconf file anymore.

Signed-off-by: Jonas Gorski [jonas.gorski@bisdn.de](mailto:jonas.gorski@bisdn.de)