### PR TITLE
ofdpa: always apply all patches 

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r25"
+PR = "r26"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "7f83aa6ce52f1909cd0bc604e5218c3ce2c6597d"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r24"
+PR = "r25"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "7f83aa6ce52f1909cd0bc604e5218c3ce2c6597d"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r23"
+PR = "r24"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "7f83aa6ce52f1909cd0bc604e5218c3ce2c6597d"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"


### PR DESCRIPTION
Always apply all patches to OFDPA/SDK to create a unified code base.

To allow the AG5648/AG7648 patches to be applied for non-matching platforms, convert the #ifdef guards to runtime checks for configuration variables, and set the variables for the appropriate platforms. The sole AS4610 patch just adds an appropriate Makefile that has no effect on other targets, and thus can always be applied.

No functional changes.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>