### PR TITLE
openbcm-gpl-modules: make patches applicable to OpenBCM

### DIFF
--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0001-gmodule-update-proc-code-for-linux-5.6.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0001-gmodule-update-proc-code-for-linux-5.6.patch
@@ -4,13 +4,13 @@ Date: Mon, 14 Dec 2020 15:55:39 +0100
 Subject: [PATCH 1/3] gmodule: update proc code for linux 5.6+
 
 ---
- systems/linux/kernel/modules/shared/gmodule.c      | 10 ++++++++++
+ sdk-6.5.24/systems/linux/kernel/modules/shared/gmodule.c      | 10 ++++++++++
  1 file changed, 10 insertions(+)
 
-diff --git a/systems/linux/kernel/modules/shared/gmodule.c b/systems/linux/kernel/modules/shared/gmodule.c
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/shared/gmodule.c b/sdk-6.5.24/systems/linux/kernel/modules/shared/gmodule.c
 index 0635b811e..d544ccd97 100644
---- a/systems/linux/kernel/modules/shared/gmodule.c
-+++ b/systems/linux/kernel/modules/shared/gmodule.c
+--- a/sdk-6.5.24/systems/linux/kernel/modules/shared/gmodule.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/shared/gmodule.c
 @@ -124,6 +124,15 @@ static int _gmodule_proc_release(struct inode * inode, struct file * file) {
      return single_release(inode, file);
  }

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch
@@ -5,13 +5,13 @@ Subject: [PATCH 2/3] kernel-modules: add dropped defines to work with 5.9+
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
- systems/linux/kernel/modules/include/lkm.h | 4 ++++
+ sdk-6.5.24/systems/linux/kernel/modules/include/lkm.h | 4 ++++
  1 file changed, 4 insertions(+)
 
-diff --git a/systems/linux/kernel/modules/include/lkm.h b/systems/linux/kernel/modules/include/lkm.h
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/include/lkm.h b/sdk-6.5.24/systems/linux/kernel/modules/include/lkm.h
 index 141029494..0b2dab92f 100644
---- a/systems/linux/kernel/modules/include/lkm.h
-+++ b/systems/linux/kernel/modules/include/lkm.h
+--- a/sdk-6.5.24/systems/linux/kernel/modules/include/lkm.h
++++ b/sdk-6.5.24/systems/linux/kernel/modules/include/lkm.h
 @@ -36,6 +36,10 @@
  #include <linux/smp_lock.h>
  #endif

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch
@@ -4,15 +4,15 @@ Date: Mon, 14 Dec 2020 15:54:54 +0100
 Subject: [PATCH 3/3] linux-kernel-bde: update API usage for 5.10
 
 ---
- systems/bde/linux/include/linux_dma.h          | 2 +-
- systems/bde/linux/kernel/linux_dma.c           | 4 ++--
- systems/bde/linux/user/kernel/linux-user-bde.c | 2 +-
+ sdk-6.5.24/systems/bde/linux/include/linux_dma.h          | 2 +-
+ sdk-6.5.24/systems/bde/linux/kernel/linux_dma.c           | 4 ++--
+ sdk-6.5.24/systems/bde/linux/user/kernel/linux-user-bde.c | 2 +-
  3 files changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/systems/bde/linux/include/linux_dma.h b/systems/bde/linux/include/linux_dma.h
+diff --git a/sdk-6.5.24/systems/bde/linux/include/linux_dma.h b/sdk-6.5.24/systems/bde/linux/include/linux_dma.h
 index da53be260..e94172ae2 100755
---- a/systems/bde/linux/include/linux_dma.h
-+++ b/systems/bde/linux/include/linux_dma.h
+--- a/sdk-6.5.24/systems/bde/linux/include/linux_dma.h
++++ b/sdk-6.5.24/systems/bde/linux/include/linux_dma.h
 @@ -23,7 +23,7 @@
  /* ioremap is broken in kernel */
  #define IOREMAP(addr, size) ((void *)KSEG1ADDR(addr))
@@ -22,10 +22,10 @@ index da53be260..e94172ae2 100755
  #endif
  
  #if defined (__mips__)
-diff --git a/systems/bde/linux/kernel/linux_dma.c b/systems/bde/linux/kernel/linux_dma.c
+diff --git a/sdk-6.5.24/systems/bde/linux/kernel/linux_dma.c b/sdk-6.5.24/systems/bde/linux/kernel/linux_dma.c
 index 475e3a8b6..59afda586 100644
---- a/systems/bde/linux/kernel/linux_dma.c
-+++ b/systems/bde/linux/kernel/linux_dma.c
+--- a/sdk-6.5.24/systems/bde/linux/kernel/linux_dma.c
++++ b/sdk-6.5.24/systems/bde/linux/kernel/linux_dma.c
 @@ -1245,7 +1245,7 @@ _sinval(int d, void *ptr, int length)
  #if defined(dma_cache_wback_inv)
       dma_cache_wback_inv((unsigned long)ptr, length);
@@ -44,10 +44,10 @@ index 475e3a8b6..59afda586 100644
      
      dma_sync_single_for_cpu(NULL, (unsigned long)ptr, length, DMA_BIDIRECTIONAL);
  #else
-diff --git a/systems/bde/linux/user/kernel/linux-user-bde.c b/systems/bde/linux/user/kernel/linux-user-bde.c
+diff --git a/sdk-6.5.24/systems/bde/linux/user/kernel/linux-user-bde.c b/sdk-6.5.24/systems/bde/linux/user/kernel/linux-user-bde.c
 index 7628fd92c..141bd53da 100644
---- a/systems/bde/linux/user/kernel/linux-user-bde.c
-+++ b/systems/bde/linux/user/kernel/linux-user-bde.c
+--- a/sdk-6.5.24/systems/bde/linux/user/kernel/linux-user-bde.c
++++ b/sdk-6.5.24/systems/bde/linux/user/kernel/linux-user-bde.c
 @@ -136,7 +136,7 @@ MODULE_LICENSE("GPL");
  #define HX5_INTC_INTR_STATUS_BASE          (HX5_INTC_INTR_STATUS_REG0)
  #define HX5_INTC_INTR_RAW_STATUS_BASE      (HX5_INTC_INTR_RAW_STATUS_REG0)

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0004-bcm-knet-proc_code.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0004-bcm-knet-proc_code.patch
@@ -1,7 +1,7 @@
-diff --git a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 index 025c6d759..b701c38c2 100755
---- a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-+++ b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -6861,6 +6861,15 @@ bkn_proc_link_write(struct file *file, const char *buf,
      return count;
  }

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch
@@ -18,10 +18,10 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 121 +++++++++++++-----
  1 file changed, 90 insertions(+), 31 deletions(-)
 
-diff --git a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 index 025c6d759..84f63b5f8 100755
---- a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-+++ b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -2097,6 +2097,42 @@ bkn_dump_pkt(uint8_t *data, int size, int txrx)
      }
  }

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0006-bcm-knet-report-link-state.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0006-bcm-knet-report-link-state.patch
@@ -7,13 +7,13 @@ We set netif carrier, so we can just use ethtool_op_get_link.
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
- systems/linux/kernel/modules/bcm-knet/bcm-knet.c | 1 +
+ sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 index 83a89ccd2..7083a5f59 100755
---- a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-+++ b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -6737,6 +6737,7 @@ bkn_get_ts_info(struct net_device *dev, struct ethtool_ts_info *info)
  
  static const struct ethtool_ops bkn_ethtool_ops = {

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0007-bcm-knet-allow-setting-speed-duplex.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0007-bcm-knet-allow-setting-speed-duplex.patch
@@ -14,10 +14,10 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 48 +++++++++++++++----
  1 file changed, 39 insertions(+), 9 deletions(-)
 
-diff --git a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 index 7083a5f59..03b06fe20 100755
---- a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-+++ b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -960,6 +960,9 @@ typedef struct bkn_priv_s {
      int phys_port;
      u32 ptp_stats_tx;

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0008-bcm-knet-implement-get_link_ksettings.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0008-bcm-knet-implement-get_link_ksettings.patch
@@ -11,10 +11,10 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 40 +++++++++++++++++++
  1 file changed, 40 insertions(+)
 
-diff --git a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 index 03b06fe20..9232c3387 100755
---- a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-+++ b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -6738,9 +6738,49 @@ bkn_get_ts_info(struct net_device *dev, struct ethtool_ts_info *info)
  }
  #endif

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0009-bcm-knet-fix-race-between-creation-and-open.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0009-bcm-knet-fix-race-between-creation-and-open.patch
@@ -38,10 +38,10 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 25 ++++++++++++++-----
  1 file changed, 19 insertions(+), 6 deletions(-)
 
-diff --git a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 index e0d86c403..b4038f18f 100755
---- a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-+++ b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -6844,12 +6844,6 @@ bkn_init_ndev(u8 *mac, char *name)
  
      bkn_dev_net_set(dev, current->nsproxy->net_ns);

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch
@@ -20,10 +20,10 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../linux/kernel/modules/bcm-knet/bcm-knet.c       | 14 ++++++--------
  1 file changed, 6 insertions(+), 8 deletions(-)
 
-diff --git a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 index b4038f18f..7046770c7 100755
---- a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-+++ b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -6804,7 +6804,11 @@ bkn_init_ndev(u8 *mac, char *name)
  #endif
  

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/xgs_iproc_compat.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/xgs_iproc_compat.patch
@@ -1,7 +1,7 @@
-diff --git a/systems/bde/linux/kernel/linux-kernel-bde.c b/systems/bde/linux/kernel/linux-kernel-bde.c
+diff --git a/sdk-6.5.24/systems/bde/linux/kernel/linux-kernel-bde.c b/sdk-6.5.24/systems/bde/linux/kernel/linux-kernel-bde.c
 index d036d2294..879297c18 100644
---- a/systems/bde/linux/kernel/linux-kernel-bde.c
-+++ b/systems/bde/linux/kernel/linux-kernel-bde.c
+--- a/sdk-6.5.24/systems/bde/linux/kernel/linux-kernel-bde.c
++++ b/sdk-6.5.24/systems/bde/linux/kernel/linux-kernel-bde.c
 @@ -64,6 +64,9 @@
  #define msi_control_reg(base)         (base + PCI_MSI_FLAGS)
  #endif

--- a/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
+++ b/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
@@ -12,17 +12,17 @@ SRC_URI = " \
           file://Makefile;subdir=src \
           file://bisdn-bcm-dev.sh \
           file://bisdn-bcm-dev.rules \
-          file://patches/0001-gmodule-update-proc-code-for-linux-5.6.patch \
-          file://patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch \
-          file://patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch \
-          file://patches/0004-bcm-knet-proc_code.patch \
-          file://patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch \
-          file://patches/0006-bcm-knet-report-link-state.patch \
-          file://patches/0007-bcm-knet-allow-setting-speed-duplex.patch \
-          file://patches/0008-bcm-knet-implement-get_link_ksettings.patch \
-          file://patches/0009-bcm-knet-fix-race-between-creation-and-open.patch \
-          file://patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch \
-          file://patches/xgs_iproc_compat.patch \
+          file://patches/0001-gmodule-update-proc-code-for-linux-5.6.patch;striplevel=2 \
+          file://patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch;striplevel=2 \
+          file://patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch;striplevel=2 \
+          file://patches/0004-bcm-knet-proc_code.patch;striplevel=2 \
+          file://patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch;striplevel=2 \
+          file://patches/0006-bcm-knet-report-link-state.patch;striplevel=2 \
+          file://patches/0007-bcm-knet-allow-setting-speed-duplex.patch;striplevel=2 \
+          file://patches/0008-bcm-knet-implement-get_link_ksettings.patch;striplevel=2 \
+          file://patches/0009-bcm-knet-fix-race-between-creation-and-open.patch;striplevel=2 \
+          file://patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch;striplevel=2 \
+          file://patches/xgs_iproc_compat.patch;striplevel=2 \
           "
 
 SRC_URI:append:agema-ag7648 = " \


### PR DESCRIPTION
Make use of striplevel to ignore the first directory. This allows us to
keep the OpenBCM patches as-is and git-am'able directly to a OpenBCM
checkout.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>