### PR TITLE
ofdpa-grpc: default stg port state to forwarding

### DIFF
--- a/recipes-extended/ofdpa-grpc/ofdpa-grpc_git.bb
+++ b/recipes-extended/ofdpa-grpc/ofdpa-grpc_git.bb
@@ -8,8 +8,8 @@ SRC_URI = " \
 "
 
 # Manually calculate expanded ${SRCPV} value
-PV = "0.3+gitAUTOINC+${@'${SRCREV}'[0:10]}"
-SRCREV = "3449f76800dd89fd3040dcacac720876b720fab5"
+PV = "0.4+gitAUTOINC+${@'${SRCREV}'[0:10]}"
+SRCREV = "84a188a00256e0a6ad502970de524a6485f1bf4b"
 
 DEPENDS = "grpc gflags glog protobuf openssl ofdpa"
 


### PR DESCRIPTION
STG groups are created with all ports in disabled state. This is fine when only working with bridged ports, but for non-bridged ports this means they cannot communicate on these VIDs anymore, and since they are not members of the bridge, they will never get set to forwarding.

Fix this by ensuring all ports are in forwarding by default. The bridge STP will take care of setting all ports to blocking when required.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>