### PR TITLE
ofdpa: agema-ag5648: fix LED activity

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r26"
+PR = "r27"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "7f83aa6ce52f1909cd0bc604e5218c3ce2c6597d"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"


### PR DESCRIPTION
Properly remap LEDs in the LED processor to fix blinking on activity.

Values taken from

https://github.com/sonic-net/sonic-buildimage/blob/ad6200029f3176eef4d08d519aac7f5ef76f0ac8/device/delta/x86_64-delta_ag5648-r0/led_proc_init.soc.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>