### PR TITLE
man-pages: force overwrite of potentially existing gz

### DIFF
--- a/recipes-extended/man-pages/man-pages_%.bbappend
+++ b/recipes-extended/man-pages/man-pages_%.bbappend
@@ -17,5 +17,5 @@ SRC_URI += " \
 
 do_install:append() {
   install -g 0 -o 0 -m 0644 ${WORKDIR}/client_*.1 ${D}${datadir}/man/man1/
-  gzip ${D}${datadir}/man/man1/client_*.1
+  gzip -f ${D}${datadir}/man/man1/client_*.1
 }


### PR DESCRIPTION
When having both github and gitlab meta-ofdpa in the path, the bbappend will be executed twice. The second execution will already zipped the man pages, so gzip will refuse to create the files.

To avoid this breaking the build, tell gzip to overwrite any existing files. Since the contents of the man pages are identical, there is no harm in doing so.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>