### PR TITLE
openbcm-gpl-modules: bcm-knet: allow marking packets as offloaded

### DIFF
--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch
@@ -1,0 +1,99 @@
+From 36973dd758d80fb25d309bb203042a1ae9ad2a00 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 26 Sep 2022 10:34:45 +0200
+Subject: [PATCH] bcm-knet: allow marking packets as offloaded
+
+When using KNET interfaces in a bridge, Linux will flood or forward any
+packets it sees according to default rules. This can be undesirable when
+the packet was already flooded or forwarded by the switch itself, since
+this will lead to the packets being duplicated.
+
+To avoid this Linux supports marking packets as forwarding offloaded,
+which prevents them from being forwarded in software, so add support for
+marking packets as such.
+
+Since this may break use cases where packets are redirected to the
+controller, but are expected to be flooded/forwarded in software, make
+this an optional flag per interface.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 22 ++++++++++++++++---
+ 1 file changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+index 7046770c7081..1e5436702cf3 100755
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+@@ -963,6 +963,9 @@ typedef struct bkn_priv_s {
+ 
+     int speed;
+     int duplex;
++
++    /* mark packets as forwarded in hardware */
++    int offload_fwd_mark;
+ } bkn_priv_t;
+ 
+ typedef struct bkn_filter_s {
+@@ -3955,6 +3958,9 @@ bkn_do_api_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+                     }
+                     DBG_DUNE(("skb protocol 0x%04x\n", skb->protocol));
+ 
++#ifdef CONFIG_NET_SWITCHDEV
++		    skb->offload_fwd_mark = priv->offload_fwd_mark;
++#endif
+                     /*
+                      * Disable configuration API while the spinlock is released.
+                      */
+@@ -4385,6 +4391,9 @@ bkn_do_skb_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+                         break;
+                     }
+ 
++#ifdef CONFIG_NET_SWITCHDEV
++		    skb->offload_fwd_mark = priv->offload_fwd_mark;
++#endif
+                     if (mirror_local) {
+                         if (mskb) {
+                             /* Process mirorr_to netif specific config. */
+@@ -6879,6 +6888,7 @@ bkn_proc_link_show(struct seq_file *m, void *v)
+                         seq_printf(m, ",%d", priv->speed);
+                 if (priv->duplex != DUPLEX_UNKNOWN)
+                         seq_printf(m, ",%s", priv->duplex == DUPLEX_FULL ? "fd" : "hd");
++                seq_printf(m, ",%s", priv->offload_fwd_mark ? "offload" : "no-offload");
+                 seq_printf(m, "\n");
+ 
+             }
+@@ -6902,14 +6912,16 @@ bkn_proc_link_open(struct inode * inode, struct file * file)
+  *
+  *   Where <netif> is a virtual network interface name, and <option> is one of
+  *
+- *   up|down     sets the detected link state
+- *   10|100|...  sets the detected link speed in Mbit/s
+- *   fd|hd       sets the detected link's duplex state (Full|Half)
++ *   up|down      sets the detected link state
++ *   10|100|...   sets the detected link speed in Mbit/s
++ *   fd|hd        sets the detected link's duplex state (Full|Half)
++ *   (no-)offload (do not) mark received packets as forwarded in hardware
+  *
+  *   Examples:
+  *   eth4=up
+  *   eth4=down
+  *   eth4=10000,fd
++ *   eth4=offload
+  */
+ static ssize_t
+ bkn_proc_link_write(struct file *file, const char *buf,
+@@ -6974,6 +6986,10 @@ bkn_proc_link_write(struct file *file, const char *buf,
+                 } else if (sscanf(ptr, "%d", &speed) == 1 &&
+                            ethtool_validate_speed(speed) == 1) {
+                     priv->speed = speed;
++                } else if (strcmp(ptr, "offload") == 0) {
++                    priv->offload_fwd_mark = 1;
++                } else if (strcmp(ptr, "no-offload") == 0) {
++                    priv->offload_fwd_mark = 0;
+                 } else {
+                     gprintk("Warning: unknown link state setting: '%s'\n", ptr);
+                 }
+-- 
+2.37.3
+

--- a/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
+++ b/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
@@ -22,6 +22,7 @@ SRC_URI = " \
           file://patches/0008-bcm-knet-implement-get_link_ksettings.patch;striplevel=2 \
           file://patches/0009-bcm-knet-fix-race-between-creation-and-open.patch;striplevel=2 \
           file://patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch;striplevel=2 \
+          file://patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch;striplevel=2 \
           file://patches/xgs_iproc_compat.patch;striplevel=2 \
           "
 


### PR DESCRIPTION
When using KNET interfaces in a bridge, Linux will flood or forward any packets it sees according to default rules. This can be undesirable when the packet was already flooded or forwarded by the switch itself, since this will lead to the packets being duplicated.

To avoid this Linux supports marking packets as forwarding offloaded, which prevents them from being forwarded in software, so add support for marking packets as such.

Since this may break use cases where packets are redirected to the controller, but are expected to be flooded/forwarded in software, make this an optional flag per interface.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>