### PR TITLE
ofdpa: ofagent: fill manufacturer and hardware description from ONIE

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -6,7 +6,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 PR = "r27"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "7f83aa6ce52f1909cd0bc604e5218c3ce2c6597d"
+SRCREV_ofdpa = "c860f125285a7683fe97f52941911edd63ed7c98"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
Instead of hardcoding the manufacturer and hardware description in the binary, let's read out the values from ONIE and fill the fields with appropriate values at runtime.

Set the fallback values to "unknown", as we don't know on what hardware we do run in this case.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>