### PR TITLE
openbcm-gpl-modules: update for linux 6.1

### DIFF
--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0001-gmodule-update-proc-code-for-linux-5.6.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0001-gmodule-update-proc-code-for-linux-5.6.patch
@@ -1,14 +1,14 @@
-From 69c49faffef38e5369ed61d37f670698e81fda17 Mon Sep 17 00:00:00 2001
+From 88564ed49737d47986b859c3fcadce9a0ac6a19a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 15:55:39 +0100
-Subject: [PATCH 1/3] gmodule: update proc code for linux 5.6+
+Subject: [PATCH 01/14] gmodule: update proc code for linux 5.6+
 
 ---
- sdk-6.5.24/systems/linux/kernel/modules/shared/gmodule.c      | 10 ++++++++++
+ .../systems/linux/kernel/modules/shared/gmodule.c      | 10 ++++++++++
  1 file changed, 10 insertions(+)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/shared/gmodule.c b/sdk-6.5.24/systems/linux/kernel/modules/shared/gmodule.c
-index 0635b811e..d544ccd97 100644
+index 0635b811ed8e..55a9ffc6c350 100644
 --- a/sdk-6.5.24/systems/linux/kernel/modules/shared/gmodule.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/shared/gmodule.c
 @@ -124,6 +124,15 @@ static int _gmodule_proc_release(struct inode * inode, struct file * file) {
@@ -36,5 +36,5 @@ index 0635b811e..d544ccd97 100644
  int
  gmodule_vpprintf(char** page_ptr, const char* fmt, va_list args)
 -- 
-2.33.0
+2.38.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch
@@ -1,7 +1,7 @@
-From ece765ce272a2467075a29a4ad031602f52f31ae Mon Sep 17 00:00:00 2001
+From 8b2a4663c3201ecf3cb6b5398cb045be677698ac Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 16:02:44 +0100
-Subject: [PATCH 2/3] kernel-modules: add dropped defines to work with 5.9+
+Subject: [PATCH 02/14] kernel-modules: add dropped defines to work with 5.9+
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 4 insertions(+)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/include/lkm.h b/sdk-6.5.24/systems/linux/kernel/modules/include/lkm.h
-index 141029494..0b2dab92f 100644
+index 1410294944eb..0b2dab92fda4 100644
 --- a/sdk-6.5.24/systems/linux/kernel/modules/include/lkm.h
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/include/lkm.h
 @@ -36,6 +36,10 @@
@@ -24,5 +24,5 @@ index 141029494..0b2dab92f 100644
  /* Helper defines for multi-version kernel  support */
  #if LINUX_VERSION_CODE < KERNEL_VERSION(2,5,0)
 -- 
-2.33.0
+2.38.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch
@@ -1,7 +1,7 @@
-From 064ad352af78a6f91a891332e9b42ab6a7e9e4a0 Mon Sep 17 00:00:00 2001
+From d4e7aed84944407c97e6a9413e98048789f7cac2 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 15:54:54 +0100
-Subject: [PATCH 3/3] linux-kernel-bde: update API usage for 5.10
+Subject: [PATCH 03/14] linux-kernel-bde: update API usage for 5.10
 
 ---
  sdk-6.5.24/systems/bde/linux/include/linux_dma.h          | 2 +-
@@ -10,7 +10,7 @@ Subject: [PATCH 3/3] linux-kernel-bde: update API usage for 5.10
  3 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/sdk-6.5.24/systems/bde/linux/include/linux_dma.h b/sdk-6.5.24/systems/bde/linux/include/linux_dma.h
-index da53be260..e94172ae2 100755
+index da53be260839..e94172ae28c9 100755
 --- a/sdk-6.5.24/systems/bde/linux/include/linux_dma.h
 +++ b/sdk-6.5.24/systems/bde/linux/include/linux_dma.h
 @@ -23,7 +23,7 @@
@@ -23,7 +23,7 @@ index da53be260..e94172ae2 100755
  
  #if defined (__mips__)
 diff --git a/sdk-6.5.24/systems/bde/linux/kernel/linux_dma.c b/sdk-6.5.24/systems/bde/linux/kernel/linux_dma.c
-index 475e3a8b6..59afda586 100644
+index 475e3a8b6b96..59afda5867f3 100644
 --- a/sdk-6.5.24/systems/bde/linux/kernel/linux_dma.c
 +++ b/sdk-6.5.24/systems/bde/linux/kernel/linux_dma.c
 @@ -1245,7 +1245,7 @@ _sinval(int d, void *ptr, int length)
@@ -45,7 +45,7 @@ index 475e3a8b6..59afda586 100644
      dma_sync_single_for_cpu(NULL, (unsigned long)ptr, length, DMA_BIDIRECTIONAL);
  #else
 diff --git a/sdk-6.5.24/systems/bde/linux/user/kernel/linux-user-bde.c b/sdk-6.5.24/systems/bde/linux/user/kernel/linux-user-bde.c
-index 7628fd92c..141bd53da 100644
+index 7628fd92c414..141bd53dade6 100644
 --- a/sdk-6.5.24/systems/bde/linux/user/kernel/linux-user-bde.c
 +++ b/sdk-6.5.24/systems/bde/linux/user/kernel/linux-user-bde.c
 @@ -136,7 +136,7 @@ MODULE_LICENSE("GPL");
@@ -58,5 +58,5 @@ index 7628fd92c..141bd53da 100644
  #define HX5_IHOST_GICD_ISENABLERN_0        (0x10781100)
  #define HX5_IHOST_GICD_ISENABLERN_1        (0x10781104)
 -- 
-2.33.0
+2.38.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0004-bcm-knet-update-API-for-linux-5.6.0.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0004-bcm-knet-update-API-for-linux-5.6.0.patch
@@ -1,5 +1,14 @@
+From 2b71b921c784b5a083e81bbd463bb8430d86962f Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 18 Nov 2022 16:12:08 +0100
+Subject: [PATCH 04/14] bcm-knet: update API for linux 5.6.0
+
+---
+ .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 71 ++++++++++++++++++-
+ 1 file changed, 69 insertions(+), 2 deletions(-)
+
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-index 025c6d759..b701c38c2 100755
+index 025c6d759840..b701c38c2027 100755
 --- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -6861,6 +6861,15 @@ bkn_proc_link_write(struct file *file, const char *buf,
@@ -171,3 +180,6 @@ index 025c6d759..b701c38c2 100755
  
  static int
  bkn_proc_init(void)
+-- 
+2.38.1
+

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch
@@ -1,7 +1,7 @@
-From 7c710f296899a0cee910a172c66b5ced745e947e Mon Sep 17 00:00:00 2001
+From 8e16ebdaa76e8799623cd2b6af2a3578261f689a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 4 Feb 2022 12:34:02 +0100
-Subject: [PATCH] bcm-knet: strip vlan tag if received untagged at port
+Subject: [PATCH 05/14] bcm-knet: strip vlan tag if received untagged at port
 
 The CPU port will always add a vlan tag, but we can check the header for
 the state at reception. If it was received untagged, strip the vlan tag
@@ -19,7 +19,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 90 insertions(+), 31 deletions(-)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-index 025c6d759..84f63b5f8 100755
+index b701c38c2027..10d08f798ab0 100755
 --- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -2097,6 +2097,42 @@ bkn_dump_pkt(uint8_t *data, int size, int txrx)
@@ -202,5 +202,5 @@ index 025c6d759..84f63b5f8 100755
                          rx_cb_meta = sand_scratch_data;
                      } else {
 -- 
-2.35.1
+2.38.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0006-bcm-knet-report-link-state.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0006-bcm-knet-report-link-state.patch
@@ -1,7 +1,7 @@
-From 89a419c8ddfcc4bc660cb65196e720fbefc8fb8c Mon Sep 17 00:00:00 2001
+From 2990e46a90ace0074c4f6308814251132f947cae Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 12:11:54 +0100
-Subject: [PATCH 1/3] bcm-knet: report link state
+Subject: [PATCH 06/14] bcm-knet: report link state
 
 We set netif carrier, so we can just use ethtool_op_get_link.
 
@@ -11,7 +11,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 1 insertion(+)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-index 83a89ccd2..7083a5f59 100755
+index 10d08f798ab0..e03de2b76fa3 100755
 --- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -6737,6 +6737,7 @@ bkn_get_ts_info(struct net_device *dev, struct ethtool_ts_info *info)
@@ -23,5 +23,5 @@ index 83a89ccd2..7083a5f59 100755
      .get_ts_info        = bkn_get_ts_info,
  #endif
 -- 
-2.35.1
+2.38.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0007-bcm-knet-allow-setting-speed-duplex.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0007-bcm-knet-allow-setting-speed-duplex.patch
@@ -1,7 +1,7 @@
-From 8dc240ab30a054fb825d58b0a25a84aa516ca681 Mon Sep 17 00:00:00 2001
+From 2d2a622e51f16fd61728f62562974d3fe60b6188 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 14:28:11 +0100
-Subject: [PATCH 2/3] bcm-knet: allow setting speed/duplex
+Subject: [PATCH 07/14] bcm-knet: allow setting speed/duplex
 
 To allow better emulation of physical port devices, extend the link
 state settings to also include link speed and duplex.
@@ -15,7 +15,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 39 insertions(+), 9 deletions(-)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-index 7083a5f59..03b06fe20 100755
+index e03de2b76fa3..eecd60db14e8 100755
 --- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -960,6 +960,9 @@ typedef struct bkn_priv_s {
@@ -115,5 +115,5 @@ index 7083a5f59..03b06fe20 100755
              spin_unlock_irqrestore(&sinfo->lock, flags);
              return count;
 -- 
-2.35.1
+2.38.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0008-bcm-knet-implement-get_link_ksettings.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0008-bcm-knet-implement-get_link_ksettings.patch
@@ -1,7 +1,7 @@
-From 2b31dd37748d8a58743334576ea9cebf78de4359 Mon Sep 17 00:00:00 2001
+From 40db6ca9f9bc12bb432f2200e388d94a8d199827 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 14:35:49 +0100
-Subject: [PATCH 3/3] bcm-knet: implement get_link_ksettings
+Subject: [PATCH 08/14] bcm-knet: implement get_link_ksettings
 
 To allow programs like ethtool access to the link speed, implement the
 get_link_ksettings callback.
@@ -12,7 +12,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 40 insertions(+)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-index 03b06fe20..9232c3387 100755
+index eecd60db14e8..681328485583 100755
 --- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -6738,9 +6738,49 @@ bkn_get_ts_info(struct net_device *dev, struct ethtool_ts_info *info)
@@ -66,5 +66,5 @@ index 03b06fe20..9232c3387 100755
      .get_ts_info        = bkn_get_ts_info,
  #endif
 -- 
-2.35.1
+2.38.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0009-bcm-knet-fix-race-between-creation-and-open.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0009-bcm-knet-fix-race-between-creation-and-open.patch
@@ -1,7 +1,7 @@
-From 7d61bf3b91d6541676c281cc9bbf7d83f8360516 Mon Sep 17 00:00:00 2001
+From e6e159d293336aa858dc9b030596b9d66964ec0f Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 20 Apr 2022 16:35:24 +0200
-Subject: [PATCH] bcm-knet: fix race between creation and open
+Subject: [PATCH 09/14] bcm-knet: fix race between creation and open
 
 When creating a netif, the netif will be registered and made available
 to userspace before its private data is initialized.
@@ -39,7 +39,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 19 insertions(+), 6 deletions(-)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-index e0d86c403..b4038f18f 100755
+index 681328485583..9b347a6fe928 100755
 --- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -6844,12 +6844,6 @@ bkn_init_ndev(u8 *mac, char *name)
@@ -55,7 +55,7 @@ index e0d86c403..b4038f18f 100755
      DBG_VERB(("Created Ethernet device %s.\n", dev->name));
  
      return dev;
-@@ -8662,6 +8656,18 @@ bkn_knet_netif_create(kcom_msg_netif_create_t *kmsg, int len)
+@@ -8729,6 +8723,18 @@ bkn_knet_netif_create(kcom_msg_netif_create_t *kmsg, int len)
      DBG_VERB(("Assigned ID %d to Ethernet device %s\n",
                priv->id, dev->name));
  
@@ -74,7 +74,7 @@ index e0d86c403..b4038f18f 100755
      kmsg->netif.id = priv->id;
      memcpy(kmsg->netif.macaddr, dev->dev_addr, 6);
      memcpy(kmsg->netif.name, dev->name, KCOM_NETIF_NAME_MAX - 1);
-@@ -9491,6 +9497,13 @@ bkn_knet_dev_init(int d)
+@@ -9558,6 +9564,13 @@ bkn_knet_dev_init(int d)
          priv->id = -1;
      }
  
@@ -89,5 +89,5 @@ index e0d86c403..b4038f18f 100755
          netif_napi_add(dev, &sinfo->napi, bkn_poll, napi_weight);
      }
 -- 
-2.35.1
+2.38.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch
@@ -1,7 +1,7 @@
-From df20798becb4e6d2feda60b086c7ce5c1b9e4f68 Mon Sep 17 00:00:00 2001
+From 1c59f49b1cd6d1ba9cc4206cfa69d2593bc3258c Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 25 Apr 2022 10:48:26 +0200
-Subject: [PATCH] bcm-knet: use fully randomized mac addresses
+Subject: [PATCH 10/14] bcm-knet: use fully randomized mac addresses
 
 Instead of using partially randomized mac addresses with a Broadcom OUI
 prefix, use fully randomized mac addresses for generated virtualized
@@ -21,7 +21,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 6 insertions(+), 8 deletions(-)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-index b4038f18f..7046770c7 100755
+index 9b347a6fe928..329f1066a511 100755
 --- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -6804,7 +6804,11 @@ bkn_init_ndev(u8 *mac, char *name)
@@ -37,7 +37,7 @@ index b4038f18f..7046770c7 100755
  
      /* Device information -- not available right now */
      dev->irq = 0;
-@@ -8529,7 +8533,6 @@ bkn_knet_netif_create(kcom_msg_netif_create_t *kmsg, int len)
+@@ -8596,7 +8600,6 @@ bkn_knet_netif_create(kcom_msg_netif_create_t *kmsg, int len)
      bkn_priv_t *priv, *lpriv;
      unsigned long flags;
      int found, id;
@@ -45,7 +45,7 @@ index b4038f18f..7046770c7 100755
  
      kmsg->hdr.type = KCOM_MSG_TYPE_RSP;
  
-@@ -8556,12 +8559,7 @@ bkn_knet_netif_create(kcom_msg_netif_create_t *kmsg, int len)
+@@ -8623,12 +8626,7 @@ bkn_knet_netif_create(kcom_msg_netif_create_t *kmsg, int len)
          return sizeof(kcom_msg_hdr_t);
      }
  
@@ -60,5 +60,5 @@ index b4038f18f..7046770c7 100755
          return sizeof(kcom_msg_hdr_t);
      }
 -- 
-2.35.1
+2.38.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch
@@ -1,7 +1,7 @@
-From 36973dd758d80fb25d309bb203042a1ae9ad2a00 Mon Sep 17 00:00:00 2001
+From c03281e4a0fc0ce564df368875f9c009c1ebc0f7 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 26 Sep 2022 10:34:45 +0200
-Subject: [PATCH] bcm-knet: allow marking packets as offloaded
+Subject: [PATCH 11/14] bcm-knet: allow marking packets as offloaded
 
 When using KNET interfaces in a bridge, Linux will flood or forward any
 packets it sees according to default rules. This can be undesirable when
@@ -22,7 +22,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 19 insertions(+), 3 deletions(-)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-index 7046770c7081..1e5436702cf3 100755
+index 329f1066a511..dd36bd125865 100755
 --- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -963,6 +963,9 @@ typedef struct bkn_priv_s {
@@ -95,5 +95,5 @@ index 7046770c7081..1e5436702cf3 100755
                      gprintk("Warning: unknown link state setting: '%s'\n", ptr);
                  }
 -- 
-2.37.3
+2.38.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0012-bcm-knet-replace-open-coded-mac-change-code-with-eth.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0012-bcm-knet-replace-open-coded-mac-change-code-with-eth.patch
@@ -1,0 +1,64 @@
+From a8917b2bcbbdbe6f137308e8f3297509bdf82f71 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 18 Nov 2022 16:24:41 +0100
+Subject: [PATCH 12/14] bcm-knet: replace open coded mac change code with
+ eth_mac_addr
+
+Linux 5.17 made netdev->dev_addr[] constant, so we cannot modify it
+anymore. Since bkn_set_mac_address() just directly sets the mac address,
+we can replace it with the generic eth_mac_addr() implementation, and
+set the IFF_LIVE_ADDR_CHANGE flag to allow MAC address changes while the
+device is up, as before.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 19 ++-----------------
+ 1 file changed, 2 insertions(+), 17 deletions(-)
+
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+index dd36bd125865..3abacd4a1f1e 100755
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+@@ -5513,22 +5513,6 @@ bkn_open(struct net_device *dev)
+     return 0;
+ }
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,29))
+-static int
+-bkn_set_mac_address(struct net_device *dev, void *addr)
+-{
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,12))
+-    if (!is_valid_ether_addr((const u8*)(((struct sockaddr *)addr)->sa_data))) {
+-#else
+-    if (!is_valid_ether_addr(((struct sockaddr *)addr)->sa_data)) {
+-#endif
+-        return -EINVAL;
+-    }
+-    memcpy(dev->dev_addr, ((struct sockaddr *)addr)->sa_data, dev->addr_len);
+-    return 0;
+-}
+-#endif
+-
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,29))
+ static int
+ bkn_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
+@@ -6661,7 +6645,7 @@ static const struct net_device_ops bkn_netdev_ops = {
+     .ndo_get_stats       = bkn_get_stats,
+     .ndo_validate_addr   = eth_validate_addr,
+     .ndo_set_rx_mode     = bkn_set_multicast_list,
+-    .ndo_set_mac_address = bkn_set_mac_address,
++    .ndo_set_mac_address = eth_mac_addr,
+     .ndo_do_ioctl        = bkn_ioctl,
+     .ndo_tx_timeout      = NULL,
+     .ndo_change_mtu      = bkn_change_mtu,
+@@ -6835,6 +6819,7 @@ bkn_init_ndev(u8 *mac, char *name)
+     /* Device vectors */
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,29))
+     dev->netdev_ops = &bkn_netdev_ops;
++    dev->priv_flags |= IFF_LIVE_ADDR_CHANGE;
+ #else
+     dev->open = bkn_open;
+     dev->hard_start_xmit = bkn_tx;
+-- 
+2.38.1
+

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0013-bcm-knet-update-API-for-kernel-5.19.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0013-bcm-knet-update-API-for-kernel-5.19.patch
@@ -1,0 +1,63 @@
+From 705c19e8532da3bed7284eab3dc08ccd1c2e64b8 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 18 Nov 2022 16:46:01 +0100
+Subject: [PATCH 13/14] bcm-knet: update API for kernel 5.19
+
+Update kernel API usage for 5.18 and 5.19:
+
+5.18 dropped pci_set_dma_mask(), which was just a wrapper for
+dma_set_mask(), so just call dma_set_mask() directly.
+
+5.19 dropped the weight argument from netif_napi_add() as most users
+just passed the default value, and added a new call
+netif_napi_add_weight() for passing a custom weight value.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../linux/kernel/modules/bcm-knet/bcm-knet.c     | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+index 3abacd4a1f1e..d5b3338d7c26 100755
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+@@ -302,6 +302,18 @@ static int napi_weight = 0;
+ 
+ /* Compatibility */
+ 
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0))
++#define NETIF_NAPI_ADD(dev, napi, poll, weight) netif_napi_add((dev), (napi), (poll), (weight))
++#else
++#define NETIF_NAPI_ADD(dev, napi, poll, weight) netif_napi_add_weight((dev), (napi), (poll), (weight))
++#endif
++
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0))
++#define PCI_SET_DMA_MASK(pdev, mask) pci_set_dma_mask((pdev), (mask))
++#else
++#define PCI_SET_DMA_MASK(pdev, mask) dma_set_mask(&(pdev)->dev, (mask))
++#endif
++
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,7,0))
+ #define NETDEV_UPDATE_TRANS_START_TIME(dev) dev->trans_start = jiffies
+ #else
+@@ -8432,7 +8444,7 @@ bkn_knet_hw_init(kcom_msg_hw_init_t *kmsg, int len)
+     /* Ensure 32-bit PCI DMA is mapped properly on 64-bit platforms */
+     dev_type = kernel_bde->get_dev_type(sinfo->dev_no);
+     if (dev_type & BDE_PCI_DEV_TYPE && sinfo->cmic_type != 'x') {
+-        if (pci_set_dma_mask(sinfo->pdev, 0xffffffff)) {
++        if (PCI_SET_DMA_MASK(sinfo->pdev, 0xffffffff)) {
+             cfg_api_unlock(sinfo, &flags);
+             gprintk("No suitable DMA available for SKBs\n");
+             kmsg->hdr.status = KCOM_E_RESOURCE;
+@@ -9571,7 +9583,7 @@ bkn_knet_dev_init(int d)
+     }
+ 
+     if (use_napi) {
+-        netif_napi_add(dev, &sinfo->napi, bkn_poll, napi_weight);
++        NETIF_NAPI_ADD(dev, &sinfo->napi, bkn_poll, napi_weight);
+     }
+     return 0;
+ }
+-- 
+2.38.1
+

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0014-linux-kernel-bde-use-platform_get_irq.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0014-linux-kernel-bde-use-platform_get_irq.patch
@@ -1,0 +1,45 @@
+From 9a144ef3b6d4b6695edbcabfa6c40b02a641f910 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 21 Nov 2022 12:01:36 +0100
+Subject: [PATCH 14/14] linux-kernel-bde: use platform_get_irq()
+
+The Kernel stopped providing platform resources for IRQs of device tree
+backed platform devices[1], and instead requires calling
+platform_get_irq(), so do that. This also simplifies the code.
+
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a1a2b7125e1079cfcc13a116aa3af3df2f9e002b
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ sdk-6.5.24/systems/bde/linux/kernel/linux-kernel-bde.c | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/sdk-6.5.24/systems/bde/linux/kernel/linux-kernel-bde.c b/sdk-6.5.24/systems/bde/linux/kernel/linux-kernel-bde.c
+index 1c778e5be06b..65d2b1aee410 100644
+--- a/sdk-6.5.24/systems/bde/linux/kernel/linux-kernel-bde.c
++++ b/sdk-6.5.24/systems/bde/linux/kernel/linux-kernel-bde.c
+@@ -795,10 +795,7 @@ iproc_cmicd_probe(struct platform_device *pldev)
+         int i;
+         memset(iproc_cmicx_irqs, 0, IHOST_CMICX_MAX_INTRS*sizeof(uint32_t));
+         for (i = 0; i < IHOST_CMICX_MAX_INTRS; i++) {
+-            irqres = iproc_platform_get_resource(pldev, IORESOURCE_IRQ, i);
+-            if (irqres) {
+-                iproc_cmicx_irqs[i] = irqres->start;
+-            }
++            iproc_cmicx_irqs[i] = platform_get_irq(pldev, i);
+             if (debug >= 1) {
+                 gprintk("iproc_cmicx_irqs[%d] = %d\n", i, iproc_cmicx_irqs[i]);
+             }
+@@ -807,8 +804,7 @@ iproc_cmicd_probe(struct platform_device *pldev)
+     } else
+ #endif
+     {
+-        irqres = iproc_platform_get_resource(pldev, IORESOURCE_IRQ, 0);
+-        ctrl->iLine = irqres->start;
++        ctrl->iLine = platform_get_irq(pldev, 0);
+     }
+ 
+     ctrl->isr = NULL;
+-- 
+2.38.1
+

--- a/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
+++ b/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
@@ -15,7 +15,7 @@ SRC_URI = " \
           file://patches/0001-gmodule-update-proc-code-for-linux-5.6.patch;striplevel=2 \
           file://patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch;striplevel=2 \
           file://patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch;striplevel=2 \
-          file://patches/0004-bcm-knet-proc_code.patch;striplevel=2 \
+          file://patches/0004-bcm-knet-update-API-for-linux-5.6.0.patch;striplevel=2 \
           file://patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch;striplevel=2 \
           file://patches/0006-bcm-knet-report-link-state.patch;striplevel=2 \
           file://patches/0007-bcm-knet-allow-setting-speed-duplex.patch;striplevel=2 \
@@ -23,6 +23,9 @@ SRC_URI = " \
           file://patches/0009-bcm-knet-fix-race-between-creation-and-open.patch;striplevel=2 \
           file://patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch;striplevel=2 \
           file://patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch;striplevel=2 \
+          file://patches/0012-bcm-knet-replace-open-coded-mac-change-code-with-eth.patch;striplevel=2 \
+          file://patches/0013-bcm-knet-update-API-for-kernel-5.19.patch;striplevel=2 \
+          file://patches/0014-linux-kernel-bde-use-platform_get_irq.patch;striplevel=2 \
           "
 
 SRC_URI:append:agema-ag7648 = " \


### PR DESCRIPTION
Update the code to compile and work with Linux 6.1.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>