### PR TITLE
ofdpa: fix Flow ID AVL tree entry leak

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,9 +4,9 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r27"
+PR = "r28"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "ba529fe841112aca30c1ad69d8526151d99c1873"
+SRCREV_ofdpa = "3d2e4d63fdfc81f5b3423c27a8410d011f20a700"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
When deleting looked up flows (e.g. via cookie), their ID table tree entry was not deleted as their flowId field was not initialized. This eventually lead to the ID table tree running full:

    Dec 06 09:07:00 accton-as4610 ofdpa[1016]: ofdbFlowAdd: Flow ID AVL tree full.

Fix this by always initialzing the flowId field when retrieving flows, and add some debug messages to make investigating the issue easier in case it crops up again.

The impact is cosmetic, as nothing ever tries to look up flows by their IDs, but OF-DPA spams the log on each flow deletion/modification attempt.

Fixes #54.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>