### PR TITLE
ofdpa: add support for custom led data formats via config

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r29"
+PR = "r30"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "3d2e4d63fdfc81f5b3423c27a8410d011f20a700"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r28"
+PR = "r29"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "3d2e4d63fdfc81f5b3423c27a8410d011f20a700"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
@@ -44,6 +44,8 @@ FILES:${PN} += "\
             ${sbindir}/client* \
             ${libdir}/librpc_client*${SOLIBS} \
             ${datadir}/ofdpa/rc.soc \
+            ${datadir}/ofdpa/led/cmicx_accton.json \
+            ${datadir}/ofdpa/led/cmicx_legacy.json \
             "
 
 FILES:ofagent = "${sbindir}/ofagent \


### PR DESCRIPTION
Instead of requiring a custom patch for the SDK's ledproc, add support
for setting custom led data formats via an appropriate led command and
a json encoded array of speed/value pairs.

Use this support to replace the custom led patches with appropriate LED
scripts, allowing us to support more formats without requiring patching
the SDK.

Currently this format assumes a very simple speed to LED data value
mapping that is identical for all ports and LED controllers.
If we ever find that we need a more fine grained control, we can always
extend the format.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>