### PR TITLE
ofdpa: switch to new generic platform implementation

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa.inc
+++ b/recipes-ofdpa/ofdpa/ofdpa.inc
@@ -8,12 +8,12 @@ BB_STRICT_CHECKSUM = "0"
 # pulled in from
 # https://github.com/bisdn/meta-switch/blob/master/conf/distro/bisdn-linux.conf
 SRC_URI = " \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${MACHINE_ARCH}/ofagent_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${MACHINE_ARCH}/ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${MACHINE_ARCH}/ofdpa-firmware-bcm56370_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${MACHINE_ARCH}/ofdpa-firmware-bcm56770_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${MACHINE_ARCH}/ofdpa-firmware-bcm56870_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${MACHINE_ARCH}/python3-ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${MACHINE_ARCH}.ipk;subdir=${P} \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofagent_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa-firmware-bcm56370_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa-firmware-bcm56770_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa-firmware-bcm56870_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/python3-ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
 "
 
 inherit bin_package

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -1,10 +1,7 @@
 DESCRIPTION = ""
 LICENSE = "CLOSED"
 
-# this is machine specific
-PACKAGE_ARCH = "${MACHINE_ARCH}"
-
-PR = "r30"
+PR = "r31"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "3d2e4d63fdfc81f5b3423c27a8410d011f20a700"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
@@ -15,11 +12,13 @@ include ofdpa.inc
 
 DEPENDS += "python3 onl"
 
-RDEPENDS:${PN} += "libgcc udev openbcm-gpl-modules"
+RDEPENDS:${PN} += "libgcc udev openbcm-gpl-modules ofdpa-platform"
 
-RDEPENDS:${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56370', '${PN}-firmware-bcm56370', '', d)}"
-RDEPENDS:${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56770', '${PN}-firmware-bcm56770', '', d)}"
-RDEPENDS:${PN} += " ${@bb.utils.contains('OFDPA_SWITCH_SUPPORT', 'BCM56870', '${PN}-firmware-bcm56870', '', d)}"
+RDEPENDS:${PN}:append:x86-64 = " \
+             ${PN}-firmware-bcm56370 \
+             ${PN}-firmware-bcm56770 \
+             ${PN}-firmware-bcm56870 \
+"
 
 SYSTEMD_PACKAGES = "${PN} ofagent"
 SYSTEMD_SERVICE:${PN} = "ofdpa.service"
@@ -44,8 +43,6 @@ FILES:${PN} += "\
             ${sbindir}/client* \
             ${libdir}/librpc_client*${SOLIBS} \
             ${datadir}/ofdpa/rc.soc \
-            ${datadir}/ofdpa/led/cmicx_accton.json \
-            ${datadir}/ofdpa/led/cmicx_legacy.json \
             "
 
 FILES:ofagent = "${sbindir}/ofagent \


### PR DESCRIPTION
Add and switch to a new generic platform implementation and add a dependency to the new ofdpa-platform package with the configuration.

The new generic implementation is now a script based:

Uses imScript and config from

  /usr/share/ofdpa/platform/<onl-platform>

Using the files

  rc.soc for the imScript, and
  config.bcm parsed as SDK Config

The dport_mapping is then used for generating the portMapping.

This allows easier prototyping and adding support for new platforms without the requirement of rebuilding OF-DPA and its packages.

The generic platform does not support any SFP ops, but this is not a big deal since nothing in the OF-DPA code base makes actually used of them.

Since we now support all platforms, depend on all firmware files for x86-64. We can also now drop the LED data format JSON files, as they are now provided by the ofdpa-platform package.

Since we now support all platforms, we do not need to set ARCH to machine anymore, and share the package.

This also means the packages move from MACHINE_ARCH to PACKAGE_ARCH.