### PR TITLE
ofdpa-platform: import custom_led.bin binaries from SONiC

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa-platform/platform/x86-64-accton-as4630-54pe-r0/rc.soc
+++ b/recipes-ofdpa/ofdpa/ofdpa-platform/platform/x86-64-accton-as4630-54pe-r0/rc.soc
@@ -1,5 +1,4 @@
-# For now embedded into OF-DPA
-# m0 load 0 0x3800 /usr/share/ofdpa/platform/x86-64-accton-as4630-54pe-r0/custom_led.bin
+m0 load 0 0x3800 /usr/share/ofdpa/platform/x86-64-accton-as4630-54pe-r0/custom_led.bin
 led leddata /usr/share/ofdpa/led/cmicx_accton.json
 led start
 led auto on

--- a/recipes-ofdpa/ofdpa/ofdpa-platform/platform/x86-64-accton-as5835-54x-r0/rc.soc
+++ b/recipes-ofdpa/ofdpa/ofdpa-platform/platform/x86-64-accton-as5835-54x-r0/rc.soc
@@ -1,5 +1,4 @@
-# For now embedded into OF-DPA
-# m0 load 0 0x3800 /usr/share/ofdpa/platform/x86-64-accton-as5835-54x-r0/custom_led.bin
-led leddata /usr/share/ofdpa/led/cmicx_accton.json
+m0 load 0 0x3800 /usr/share/ofdpa/platform/x86-64-accton-as5835-54x-r0/custom_led.bin
+led leddata /usr/share/ofdpa/led/cmicx_legacy.json
 led auto on
 led start

--- a/recipes-ofdpa/ofdpa/ofdpa-platform/platform/x86-64-accton-as7726-32x-r0/rc.soc
+++ b/recipes-ofdpa/ofdpa/ofdpa-platform/platform/x86-64-accton-as7726-32x-r0/rc.soc
@@ -1,5 +1,4 @@
-# For now embedded into OF-DPA
-# m0 load 0 0x3800 /usr/share/ofdpa/platform/x86-64-accton-as7726-32x-r0/custom_led.bin
+m0 load 0 0x3800 /usr/share/ofdpa/platform/x86-64-accton-as7726-32x-r0/custom_led.bin
 led leddata /usr/share/ofdpa/led/cmicx_legacy.json
 led auto on
 led start

--- a/recipes-ofdpa/ofdpa/ofdpa-platform_1.0.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa-platform_1.0.bb
@@ -25,6 +25,7 @@ inherit allarch
 SONIC_CUSTOM_LEDS = "\
     accton/x86_64-accton_as4630_54pe-r0 \
     accton/x86_64-accton_as5835_54x-r0 \
+    accton/x86_64-accton_as7726_32x-r0 \
 "
 
 FILES:${PN} = " \

--- a/recipes-ofdpa/ofdpa/ofdpa-platform_1.0.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa-platform_1.0.bb
@@ -24,6 +24,7 @@ inherit allarch
 
 SONIC_CUSTOM_LEDS = "\
     accton/x86_64-accton_as4630_54pe-r0 \
+    accton/x86_64-accton_as5835_54x-r0 \
 "
 
 FILES:${PN} = " \

--- a/recipes-ofdpa/ofdpa/ofdpa-platform_1.0.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa-platform_1.0.bb
@@ -1,29 +1,53 @@
 SUMMARY = "OF-DPA platform configuration"
 DESCRIPTION = "Switch ASIC platform configuration files for OF-DPA (Broadcom SDK)"
 
-LICENSE = "Broadcom-OpenBCM"
+LICENSE = "Broadcom-OpenBCM & Apache-2.0"
 NO_GENERIC_LICENSE[Broadcom-OpenBCM] = "${WORKDIR}/LICENSE.Broadcom-OpenBCM"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE.Broadcom-OpenBCM;md5=1513e460208bceb2722d7e38e260aa44"
+LIC_FILES_CHKSUM = "\
+    file://${WORKDIR}/LICENSE.Broadcom-OpenBCM;md5=1513e460208bceb2722d7e38e260aa44 \
+    file://${WORKDIR}/git/LICENSE;md5=31b8e124402d908f7a5fd17902e7d4e7 \
+"
+
+# head of master as of 2023-9-20
+SRCREV = "382d68fe42ea2fd8aaf02db1a9c94c8932abce47"
 
 SRC_URI = "\
+    git://github.com/sonic-net/sonic-buildimage.git;protocol=https;branch=master \
     file://led \
     file://platform \
     file://LICENSE.Broadcom-OpenBCM \
 "
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/git"
 
 inherit allarch
+
+SONIC_CUSTOM_LEDS = "\
+"
 
 FILES:${PN} = " \
     ${datadir}/ofdpa/led \
     ${datadir}/ofdpa/platform \
 "
 
+do_configure() {
+        /usr/bin/true
+}
+
+do_compile() {
+        /usr/bin/true
+}
+
 do_install() {
         install -d -m0755 ${D}${datadir}/ofdpa/led
         install -m 0644 ${WORKDIR}/led/*.json ${D}${datadir}/ofdpa/led
         install -d -m0755 ${D}${datadir}/ofdpa/platform
         cp -R ${WORKDIR}/platform/* ${D}${datadir}/ofdpa/platform
+
+        for sonic_custom_led in ${SONIC_CUSTOM_LEDS}; do
+             onl_platform="$(basename ${sonic_custom_led} | tr '_' '-')"
+             install -m 0644 ${S}/device/${sonic_custom_led}/custom_led.bin \
+                 ${D}${datadir}/ofdpa/platform/${onl_platform}/
+        done
 }
 

--- a/recipes-ofdpa/ofdpa/ofdpa-platform_1.0.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa-platform_1.0.bb
@@ -23,6 +23,7 @@ S = "${WORKDIR}/git"
 inherit allarch
 
 SONIC_CUSTOM_LEDS = "\
+    accton/x86_64-accton_as4630_54pe-r0 \
 "
 
 FILES:${PN} = " \


### PR DESCRIPTION
To reduce the need for embedded custom_led.bin binaries in OF-DPA, add support for importing these from the SONiC project, and add them for the Edgecore platforms we support.

There is no binary for the Celestica Questone 2A available, so that one still needs one embedded. 

~~Obviously GPL as the license is wrong, so we need to wait for https://github.com/sonic-net/sonic-buildimage/issues/14221 to be addressed before we can merge this.~~

SONiC switched their license to Apache 2.0, so no GPL issue anymore (hooray).

State of LEDs:

* as4630-54pe: LEDs light up for link, no color change for lower speed (always white)
* as5835-54x: LEDs light up after switching to legacy led data
* as7726-32x: LEDs light up as expected
