### PR TITLE
openbcm-gpl-modules: do not force loading of modules

### DIFF
--- a/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
+++ b/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
@@ -55,7 +55,8 @@ do_install:append:agema-ag7648() {
         install -m 0644 ${WORKDIR}/*.conf ${D}${sysconfdir}/modprobe.d/
 }
 
-KERNEL_MODULE_AUTOLOAD += " linux-kernel-bde linux-user-bde linux-bcm-knet"
+KERNEL_MODULE_PROBECONF:append = " linux-kernel-bde"
+module_conf_linux-kernel-bde = "softdep linux-kernel-bde post: linux-user-bde linux-bcm-knet"
 
 # The inherit of module.bbclass will automatically name module packages with
 # "kernel-module-" prefix as required by the oe-core build environment.


### PR DESCRIPTION
The linux-kernel-bde module has proper MODULE_DEVICE_TABLE lists both for openflow and pci, so there is no need to force loading it.

So instead of force loading all modules, allow on-demand loading of linux-kernel-bde and add linux-user-bde and linux-bcm-knet as softdeps so they get automatically loaded if linux-kernel-bde gets loaded.

This avoids loading the kernel modules on systems without any Broadcom switches.