### PR TITLE
ofdpa: do not crash on maximum length interface names

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -1,9 +1,9 @@
 DESCRIPTION = ""
 LICENSE = "CLOSED"
 
-PR = "r31"
+PR = "r32"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "3d2e4d63fdfc81f5b3423c27a8410d011f20a700"
+SRCREV_ofdpa = "8d10ff02e0445267b458ea19191af5a5a63ce3d6"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
The path /sys/class/net/%s/device/ with a maximum length interface name of 15 is 38 characters. This means we need a buffer of 39 bytes including the terminator, but devPath is only 38 bytes.

This causes interfaces with 15 characters to trigger a buffer overflow, and preventing OF-DPA from startup:

```
Aug 11 10:53:22 delta-ag7648 ofdpa[2210]: platformNumReservedMacsGet: Base MAC = 00:18:23:30:7b:08, num MACs = 4.
Aug 11 10:53:22 delta-ag7648 ofdpa[2210]: platformNumReservedMacsGet: start = 307b08, end = 307b0c
Aug 11 10:53:22 delta-ag7648 ofdpa[2210]: platformNumReservedMacsGet: Interface enp0s20f0 has MAC 00:18:23:30:7b:08.
Aug 11 10:53:22 delta-ag7648 ofdpa[2210]: platformNumReservedMacsGet: ifBase = 307b08
Aug 11 10:53:22 delta-ag7648 ofdpa[2210]: platformNumReservedMacsGet: Updated next free MAC to ..307b09).
Aug 11 10:53:22 delta-ag7648 ofdpa[2210]: platformNumReservedMacsGet: Interface enp0s20f2 has MAC 00:a0:c9:00:00:02.
Aug 11 10:53:22 delta-ag7648 ofdpa[2210]: *** buffer overflow detected ***: terminated
```

Fix this by increasing the buffer to be able to handle the maxium length.

Fixes: ad445763abd2 ("ofdpa: autodetect number of reserved MAC addresses instead of hardcoding it")
Reported-by: Ibtisam Tariq <ibtisam.tariq@bisdn.de>