### PR TITLE
ofdpa: ofagent: fix copying strings from ONIE data

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -3,7 +3,7 @@ LICENSE = "CLOSED"
 
 PR = "r35"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "8d10ff02e0445267b458ea19191af5a5a63ce3d6"
+SRCREV_ofdpa = "9655911ba4624eb67896c4c42c951ee07d633ecd"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
The fields from onie_info aren't fixed length strings, but rather dynamically allocated ones. So we cannot just mempcy them, but need to adhere to their actual length, else we will read over the buffers and copy random data.

Additionally, the OpenFlow spec says that these fields should be null-padded, so use strncpy, which will do that for us if the source string length is less than the destination one.

While at it, make sure we do not try to read from NULL pointers.

Fixes leaking random (static) memory contents into the ofp_desc reply.

Fixes: 2685834c920a ("ofdpa: ofagent: fill manufacturer and hardware description from ONIE")