### PR TITLE
openbcm-gpl-modules: bcm-knet: fixup DSCP value in packets to controller

### DIFF
--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0015-bcm-knet-extract-and-update-DSCP-for-IP-packets.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0015-bcm-knet-extract-and-update-DSCP-for-IP-packets.patch
@@ -1,0 +1,126 @@
+From e7b7f050d9b9dfe58134a0b67aa107ebee9fb6eb Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 6 May 2024 11:25:49 +0200
+Subject: [PATCH] bcm-knet: extract and update DSCP for IP packets
+
+For currently unknown reasons the Broadcom ASIC does not update the DSCP
+field for packets sent to controller. But the DMA header does have the
+expected DSCP value. So use the DSCP value from the DMA header to update
+IP(v6) packets if set.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 76 +++++++++++++++++++
+ 1 file changed, 76 insertions(+)
+
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+index 1e5436702cf3..3b22016c047c 100755
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+@@ -68,6 +68,7 @@
+ #include <linux/if_vlan.h>
+ #include <linux/nsproxy.h>
+ 
++#include <net/dsfield.h>
+ 
+ MODULE_AUTHOR("Broadcom Corporation");
+ MODULE_DESCRIPTION("Network Device Driver for Broadcom BCM TxRx API");
+@@ -2139,6 +2140,77 @@ bkn_pkt_is_rx_untagged(bkn_switch_info_t *sinfo, uint32_t *meta)
+     }
+ }
+ 
++static inline uint8_t
++bkn_pkt_new_dscp(bkn_switch_info_t *sinfo, uint32_t *meta)
++{
++    uint8_t dscp = 0;
++
++    /* extract DSCP field from DMA header */
++    switch (sinfo->dcb_type) {
++    case 28:
++        /*
++         * DPP: split over two words:
++         * - lower 4 bits in T28.9
++         * - upper 2 bits in T28.8
++         */
++        dscp = (meta[9] >> 28) & 0xfu;
++        dscp |= (meta[8] & 0x3u) << 4;
++        break;
++    case 23:
++    case 24:
++    case 26:
++    case 29:
++    case 31:
++    case 32:
++    case 34:
++    case 35:
++    case 37:
++	/* Triumph3 and newer */
++        dscp = (meta[11] & 0x1fu);
++        break;
++    case 36:
++	/* Trident 3 */
++        dscp = ((meta[9] >> 5) & 0x1fu);
++        break;
++    default:
++        /* currently unhandled */
++        break;
++    }
++
++    return dscp;
++}
++
++#define TOS_DSCP_MASK 0xfc
++
++static inline void
++bkn_pkt_update_dscp(bkn_switch_info_t *sinfo, uint32_t *meta, uint8_t *pkt)
++{
++    uint8_t new_dscp = bkn_pkt_new_dscp(sinfo, meta);
++    uint8_t *data = pkt + 2 * ETH_ALEN; /* point to ether type */
++    uint16_t eth_proto;
++
++    /* assume 0 means not a IP packet or no update */
++    if (new_dscp == 0)
++      return;
++
++    /* skip all VLAN headers */
++    eth_proto = *(uint16_t *)data;
++    while (eth_proto == htons(ETH_P_8021Q) ||
++           eth_proto == htons(ETH_P_8021AD)) {
++        data += VLAN_HLEN;
++        eth_proto = *(uint16_t *)data;
++    }
++
++    /* skip ether type */
++    data += ETH_TLEN;
++
++    /* update DSCP field for IPv4 and IPv6 */
++    if (eth_proto == htons(ETH_P_IP))
++        ipv4_change_dsfield((struct iphdr *)data, TOS_DSCP_MASK, new_dscp << 2);
++    else if (eth_proto == htons(ETH_P_IPV6))
++        ipv6_change_dsfield((struct ipv6hdr *)data, TOS_DSCP_MASK, new_dscp << 2);
++}
++
+ static bkn_switch_info_t *
+ bkn_sinfo_from_unit(int unit)
+ {
+@@ -3909,6 +3981,8 @@ bkn_do_api_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+                         }
+                     }
+ 
++                    bkn_pkt_update_dscp(sinfo, meta, pkt);
++
+                     skb_copy_to_linear_data(skb, pkt, pktlen);
+                     if (device_is_sand(sinfo)) {
+                         /* CRC has been stripped */
+@@ -4362,6 +4436,8 @@ bkn_do_skb_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+                         }
+                     }
+ 
++                    bkn_pkt_update_dscp(sinfo, meta, skb->data);
++
+                     if (device_is_sand(sinfo)) {
+                         rx_cb_meta = sand_scratch_data;
+                     } else {
+-- 
+2.44.0
+

--- a/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
+++ b/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
@@ -26,6 +26,7 @@ SRC_URI = " \
           file://patches/0012-bcm-knet-replace-open-coded-mac-change-code-with-eth.patch;striplevel=2 \
           file://patches/0013-bcm-knet-update-API-for-kernel-5.19.patch;striplevel=2 \
           file://patches/0014-linux-kernel-bde-use-platform_get_irq.patch;striplevel=2 \
+          file://patches/0015-bcm-knet-extract-and-update-DSCP-for-IP-packets.patch;striplevel=2 \
           "
 
 SRC_URI:append:agema-ag7648 = " \


### PR DESCRIPTION
For currently unknown reasons the Broadcom ASIC does not update the DSCP
field for packets sent to controller. But the DMA header does have the
expected DSCP value. So use the DSCP value from the DMA headers [1] to
update IP(v6) packets if set. Luckily there is a linux function for that
which also take care of updating the checksum.

Tested on Helix 4 and Trident3.

[1] https://github.com/Broadcom-Network-Switching-Software/OpenBCM/tree/master/sdk-6.5.24/include/soc/shared/dcbformats
