### PR TITLE
ofdpa: also add outer tag to inner tagged packets

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -1,9 +1,9 @@
 DESCRIPTION = ""
 LICENSE = "CLOSED"
 
-PR = "r35"
+PR = "r36"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "9655911ba4624eb67896c4c42c951ee07d633ecd"
+SRCREV_ofdpa = "f6b060788844aa0cefed4cbe700bb66202da6402"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
When creating an VID assignment flow that adds an outer tag, do not just add the tag to untagged packets, but also add it to inner tagged packets (i.e. packets with a different vlan protocol).

This makes the behavior match with the linux behavior of bridges of packets with a different protocol.

E.g. Having the following 802.1ad bridge setup:

$ bridge vlan show
port              vlan-id
port4             100
port5             100 PVID Egress Untagged

Linux behavior:

Sending 802.1q tagged packets in on port5 will make them double tagged, adding a 802.1ad tag based on PVID, then forwarded based on that.

Previous behavior:

Sending 802.1q tagged packets in on port5 get dropped.

New behaviour:

Sending 802.1q tagged packets in on port5 will make them double tagged, adding a 802.1ad tag based on PVID, then forwarded based on that.

Egress was already working fine, i.e. double tagged packets sent in on port 4 get untagged to single tagged on port 5.