### PR TITLE
ofdpa: prevent client utilities from accumuating data in /tmp

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -1,9 +1,9 @@
 DESCRIPTION = ""
 LICENSE = "CLOSED"
 
-PR = "r37"
+PR = "r38"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "a806ccb083e7d06a550e7e3abb8f2b8862ccb2fe"
+SRCREV_ofdpa = "ad81ee0561179505746eaeb2cd956d967b9e6023"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
Currently, any client using the OF-DPA API adds data to /tmp on every invocation:

* the unix client socket created is never removed
* it appends some logs to /tmp/ofdpa-client.log

Fix the first one by switching the client sockets to abstract sockets, so they don't trigger any file creation.

For the second one, reduce logging by default so that in the normal case no logging messages are generated. These logging messages were only trace messages anyway (entering/exiting function).