### PR TITLE
ofdpa: accton-as4610-30: add missing dport definitions

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,7 +4,7 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r28.7"
+PR = "r28.8"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "ad81ee0561179505746eaeb2cd956d967b9e6023"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"


### PR DESCRIPTION
Newer SDKs require each port to be dport mapped, else they cannot be addressed by unqualified port numbers.

Since we didn't setup dport mapping for ports where the dport is identical to the switch's internal port, these ports wouldn't be configurable e.g. for KNET or other functions that use unqualified port numbers.

Fix this by providing the missing dport mappings.

Fixes: 0ffe6e854c33 ("ofdpa: update SDK to 6.5.21")