### PR TITLE
ofdpa: expose per port learning configuration

### DIFF
--- a/recipes-extended/ofdpa-grpc/ofdpa-grpc_0.6.bb
+++ b/recipes-extended/ofdpa-grpc/ofdpa-grpc_0.6.bb
@@ -4,7 +4,7 @@ inherit systemd
 
 include ofdpa-grpc.inc
 
-SRCREV = "58ce2e6cacca758b5fc55c66447982e982098ceb"
+SRCREV = "a323a61ca506f5b9f9691e559a2c5b833c619435"
 
 DEPENDS += "grpc gflags glog protobuf openssl ofdpa systemd"
 

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -1,9 +1,9 @@
 DESCRIPTION = ""
 LICENSE = "CLOSED"
 
-PR = "r39"
+PR = "r40"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "055252b0378c2d3c56e06ba21ea0adc9341a3324"
+SRCREV_ofdpa = "55b00d96f9891ec7ebbf510e6bc3bdb932bc242a"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
Expose per port learning configuration via gRPC.

This is needed to implement proper port locking handling.