### PR TITLE
v4.x: ofdpa: expose per port learning configuration

### DIFF
--- a/recipes-extended/ofdpa-grpc/ofdpa-grpc_0.4.1.bb
+++ b/recipes-extended/ofdpa-grpc/ofdpa-grpc_0.4.1.bb
@@ -4,7 +4,7 @@ inherit systemd
 
 include ofdpa-grpc.inc
 
-SRCREV = "84a188a00256e0a6ad502970de524a6485f1bf4b"
+SRCREV = "03471865f9fabb58736796b33c63a70929cf950e"
 
 DEPENDS += "grpc gflags glog protobuf openssl ofdpa"
 

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,9 +4,9 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r28.9"
+PR = "r28.10"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "055252b0378c2d3c56e06ba21ea0adc9341a3324"
+SRCREV_ofdpa = "55b00d96f9891ec7ebbf510e6bc3bdb932bc242a"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -4,9 +4,9 @@ LICENSE = "CLOSED"
 # this is machine specific
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PR = "r28.8"
+PR = "r28.9"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "ad81ee0561179505746eaeb2cd956d967b9e6023"
+SRCREV_ofdpa = "055252b0378c2d3c56e06ba21ea0adc9341a3324"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
Expose per port learning configuration via gRPC.
This is needed to implement proper port locking handling.

These are backports of https://github.com/bisdn/meta-ofdpa/pull/79 and https://github.com/bisdn/meta-ofdpa/pull/75 (which is unrelated, but allows us to just use the OF-DPA version from main).