### PR TITLE
ofdpa-platform: disable lossless MMU on Edgecore AS4610

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa-platform/platform/arm-accton-as4610-30-r0/config.bcm
+++ b/recipes-ofdpa/ofdpa/ofdpa-platform/platform/arm-accton-as4610-30-r0/config.bcm
@@ -1,5 +1,6 @@
 l2_mem_entries=
 l3_mem_entries=
+mmu_lossless=0
 pbmp_xport_ge=0x0000001fffffe
 pbmp_xport_xe=0x47c0000000000
 pbmp_valid=0x47c0001ffffff

--- a/recipes-ofdpa/ofdpa/ofdpa-platform/platform/arm-accton-as4610-54-r0/config.bcm
+++ b/recipes-ofdpa/ofdpa/ofdpa-platform/platform/arm-accton-as4610-54-r0/config.bcm
@@ -1,5 +1,6 @@
 l2_mem_entries=
 l3_mem_entries=
+mmu_lossless=0
 pbmp_xport_ge=0x01fffffffffffe
 pbmp_xport_xe=0xfc000000000000
 pbmp_valid=0xfdffffffffffff


### PR DESCRIPTION
Disable lossless MMU to prevent packets copied to controller from triggering flow control and limiting packet delivery, especially of broadcast and multicast frames.

By default lossless MMU is disabled on Tomahawk and Trident 3 platforms, and only Trident 2 and Helix 4 enable it by default.

Delta AG7648 explicitly disables it in its confic, which leaves Edgecore AS4610 as the only platform to enable it.

So align it with all other platforms, and disable it there as well.

Before:

```
ubuntu@bbctrl01:~$ iperf -s -u -B 226.91.1.1%eno2 -i 1 ------------------------------------------------------------ Server listening on UDP port 5001
Joining multicast (*,G)=*,226.91.1.1 w/iface eno2
Server set to single client traffic mode (per multicast receive) UDP buffer size:  208 KByte (default)
------------------------------------------------------------ [  1] local 226.91.1.1 port 5001 connected with 10.0.0.1 port 49518
[ ID] Interval       Transfer     Bandwidth        Jitter   Lost/Total Datagrams
[  1] 0.0000-1.0000 sec  5.25 MBytes  44.0 Mbits/sec   0.143 ms 0/3744 (0%)
[  1] 1.0000-2.0000 sec  1.33 MBytes  11.2 Mbits/sec   0.050 ms 0/951 (0%)
[  1] 2.0000-3.0000 sec  1.41 MBytes  11.8 Mbits/sec   0.459 ms 0/1007 (0%)
[  1] 0.0000-3.0062 sec  8.00 MBytes  22.3 Mbits/sec   1.011 ms 0/5705 (0%)
```

After:

```
ubuntu@bbctrl01:~$ iperf -s -u -B 226.91.1.1%eno2 -i 1 ------------------------------------------------------------ Server listening on UDP port 5001
Joining multicast (*,G)=*,226.91.1.1 w/iface eno2
Server set to single client traffic mode (per multicast receive) UDP buffer size:  208 KByte (default)
------------------------------------------------------------ [  1] local 226.91.1.1 port 5001 connected with 10.0.0.1 port 34879
[ ID] Interval       Transfer     Bandwidth        Jitter   Lost/Total Datagrams
[  1] 0.0000-1.0000 sec  62.5 MBytes   524 Mbits/sec   0.000 ms 0/44585 (0%)
[  1] 1.0000-2.0000 sec  62.5 MBytes   524 Mbits/sec   0.000 ms 0/44586 (0%)
[  1] 2.0000-3.0000 sec  62.5 MBytes   524 Mbits/sec   0.001 ms 0/44577 (0%)
[  1] 0.0000-3.0000 sec   188 MBytes   524 Mbits/sec   0.001 ms 0/133748 (0%)
```