### PR TITLE
openbcm-gpl-modules: allow pushing hw counters to knet interfaces

### DIFF
--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0001-gmodule-update-proc-code-for-linux-5.6.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0001-gmodule-update-proc-code-for-linux-5.6.patch
@@ -1,7 +1,7 @@
-From 88564ed49737d47986b859c3fcadce9a0ac6a19a Mon Sep 17 00:00:00 2001
+From af0023f4e05da89fe3e46a1681f11b034fb5f8ab Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 15:55:39 +0100
-Subject: [PATCH 01/14] gmodule: update proc code for linux 5.6+
+Subject: [PATCH 01/19] gmodule: update proc code for linux 5.6+
 
 ---
  .../systems/linux/kernel/modules/shared/gmodule.c      | 10 ++++++++++
@@ -36,5 +36,5 @@ index 0635b811ed8e..55a9ffc6c350 100644
  int
  gmodule_vpprintf(char** page_ptr, const char* fmt, va_list args)
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch
@@ -1,7 +1,7 @@
-From 8b2a4663c3201ecf3cb6b5398cb045be677698ac Mon Sep 17 00:00:00 2001
+From 425a8a9adf62754df06a78e666d70db85fdcf6f8 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 16:02:44 +0100
-Subject: [PATCH 02/14] kernel-modules: add dropped defines to work with 5.9+
+Subject: [PATCH 02/19] kernel-modules: add dropped defines to work with 5.9+
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -24,5 +24,5 @@ index 1410294944eb..0b2dab92fda4 100644
  /* Helper defines for multi-version kernel  support */
  #if LINUX_VERSION_CODE < KERNEL_VERSION(2,5,0)
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch
@@ -1,7 +1,7 @@
-From d4e7aed84944407c97e6a9413e98048789f7cac2 Mon Sep 17 00:00:00 2001
+From eb4c8fcd136a3c85bff58b7c98f9ade923db98e3 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 15:54:54 +0100
-Subject: [PATCH 03/14] linux-kernel-bde: update API usage for 5.10
+Subject: [PATCH 03/19] linux-kernel-bde: update API usage for 5.10
 
 ---
  sdk-6.5.24/systems/bde/linux/include/linux_dma.h          | 2 +-
@@ -58,5 +58,5 @@ index 7628fd92c414..141bd53dade6 100644
  #define HX5_IHOST_GICD_ISENABLERN_0        (0x10781100)
  #define HX5_IHOST_GICD_ISENABLERN_1        (0x10781104)
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0004-bcm-knet-update-API-for-linux-5.6.0.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0004-bcm-knet-update-API-for-linux-5.6.0.patch
@@ -1,7 +1,7 @@
-From 2b71b921c784b5a083e81bbd463bb8430d86962f Mon Sep 17 00:00:00 2001
+From 6edc6d41bf3f5a3cde6547c4827c40e745dc0f6f Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 18 Nov 2022 16:12:08 +0100
-Subject: [PATCH 04/14] bcm-knet: update API for linux 5.6.0
+Subject: [PATCH 04/19] bcm-knet: update API for linux 5.6.0
 
 ---
  .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 71 ++++++++++++++++++-
@@ -181,5 +181,5 @@ index 025c6d759840..b701c38c2027 100755
  static int
  bkn_proc_init(void)
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch
@@ -1,7 +1,7 @@
-From 8e16ebdaa76e8799623cd2b6af2a3578261f689a Mon Sep 17 00:00:00 2001
+From bf2dda4bfe2a12d121e97f4875f15ef34b6d8ec0 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 4 Feb 2022 12:34:02 +0100
-Subject: [PATCH 05/14] bcm-knet: strip vlan tag if received untagged at port
+Subject: [PATCH 05/19] bcm-knet: strip vlan tag if received untagged at port
 
 The CPU port will always add a vlan tag, but we can check the header for
 the state at reception. If it was received untagged, strip the vlan tag
@@ -202,5 +202,5 @@ index b701c38c2027..10d08f798ab0 100755
                          rx_cb_meta = sand_scratch_data;
                      } else {
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0006-bcm-knet-report-link-state.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0006-bcm-knet-report-link-state.patch
@@ -1,7 +1,7 @@
-From 2990e46a90ace0074c4f6308814251132f947cae Mon Sep 17 00:00:00 2001
+From 3a9f1b8a791e5dc139eb53410bc2f26ecef76211 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 12:11:54 +0100
-Subject: [PATCH 06/14] bcm-knet: report link state
+Subject: [PATCH 06/19] bcm-knet: report link state
 
 We set netif carrier, so we can just use ethtool_op_get_link.
 
@@ -23,5 +23,5 @@ index 10d08f798ab0..e03de2b76fa3 100755
      .get_ts_info        = bkn_get_ts_info,
  #endif
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0007-bcm-knet-allow-setting-speed-duplex.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0007-bcm-knet-allow-setting-speed-duplex.patch
@@ -1,7 +1,7 @@
-From 2d2a622e51f16fd61728f62562974d3fe60b6188 Mon Sep 17 00:00:00 2001
+From 8b7522199a3e718dcecf55f8dd361a07ce435ff2 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 14:28:11 +0100
-Subject: [PATCH 07/14] bcm-knet: allow setting speed/duplex
+Subject: [PATCH 07/19] bcm-knet: allow setting speed/duplex
 
 To allow better emulation of physical port devices, extend the link
 state settings to also include link speed and duplex.
@@ -115,5 +115,5 @@ index e03de2b76fa3..eecd60db14e8 100755
              spin_unlock_irqrestore(&sinfo->lock, flags);
              return count;
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0008-bcm-knet-implement-get_link_ksettings.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0008-bcm-knet-implement-get_link_ksettings.patch
@@ -1,7 +1,7 @@
-From 40db6ca9f9bc12bb432f2200e388d94a8d199827 Mon Sep 17 00:00:00 2001
+From c6fa657413487f9957f9f3bbdfe944af934318e4 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 14:35:49 +0100
-Subject: [PATCH 08/14] bcm-knet: implement get_link_ksettings
+Subject: [PATCH 08/19] bcm-knet: implement get_link_ksettings
 
 To allow programs like ethtool access to the link speed, implement the
 get_link_ksettings callback.
@@ -66,5 +66,5 @@ index eecd60db14e8..681328485583 100755
      .get_ts_info        = bkn_get_ts_info,
  #endif
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0009-bcm-knet-fix-race-between-creation-and-open.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0009-bcm-knet-fix-race-between-creation-and-open.patch
@@ -1,7 +1,7 @@
-From e6e159d293336aa858dc9b030596b9d66964ec0f Mon Sep 17 00:00:00 2001
+From 66b1242a93d5e05d34e77d7c0ddbe06eaf635a2e Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 20 Apr 2022 16:35:24 +0200
-Subject: [PATCH 09/14] bcm-knet: fix race between creation and open
+Subject: [PATCH 09/19] bcm-knet: fix race between creation and open
 
 When creating a netif, the netif will be registered and made available
 to userspace before its private data is initialized.
@@ -89,5 +89,5 @@ index 681328485583..9b347a6fe928 100755
          netif_napi_add(dev, &sinfo->napi, bkn_poll, napi_weight);
      }
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch
@@ -1,7 +1,7 @@
-From 1c59f49b1cd6d1ba9cc4206cfa69d2593bc3258c Mon Sep 17 00:00:00 2001
+From 70c844eb9889a4da8e6f7449cbbd88a0bb102d22 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 25 Apr 2022 10:48:26 +0200
-Subject: [PATCH 10/14] bcm-knet: use fully randomized mac addresses
+Subject: [PATCH 10/19] bcm-knet: use fully randomized mac addresses
 
 Instead of using partially randomized mac addresses with a Broadcom OUI
 prefix, use fully randomized mac addresses for generated virtualized
@@ -60,5 +60,5 @@ index 9b347a6fe928..329f1066a511 100755
          return sizeof(kcom_msg_hdr_t);
      }
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch
@@ -1,7 +1,7 @@
-From c03281e4a0fc0ce564df368875f9c009c1ebc0f7 Mon Sep 17 00:00:00 2001
+From 535f8430806f374b800c89da04c42c74d00a407d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 26 Sep 2022 10:34:45 +0200
-Subject: [PATCH 11/14] bcm-knet: allow marking packets as offloaded
+Subject: [PATCH 11/19] bcm-knet: allow marking packets as offloaded
 
 When using KNET interfaces in a bridge, Linux will flood or forward any
 packets it sees according to default rules. This can be undesirable when
@@ -95,5 +95,5 @@ index 329f1066a511..dd36bd125865 100755
                      gprintk("Warning: unknown link state setting: '%s'\n", ptr);
                  }
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0012-bcm-knet-replace-open-coded-mac-change-code-with-eth.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0012-bcm-knet-replace-open-coded-mac-change-code-with-eth.patch
@@ -1,7 +1,7 @@
-From a8917b2bcbbdbe6f137308e8f3297509bdf82f71 Mon Sep 17 00:00:00 2001
+From 754d1b1517b9f211172770aa309e1dd048f97c2b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 18 Nov 2022 16:24:41 +0100
-Subject: [PATCH 12/14] bcm-knet: replace open coded mac change code with
+Subject: [PATCH 12/19] bcm-knet: replace open coded mac change code with
  eth_mac_addr
 
 Linux 5.17 made netdev->dev_addr[] constant, so we cannot modify it
@@ -60,5 +60,5 @@ index dd36bd125865..3abacd4a1f1e 100755
      dev->open = bkn_open;
      dev->hard_start_xmit = bkn_tx;
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0013-bcm-knet-update-API-for-kernel-5.19.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0013-bcm-knet-update-API-for-kernel-5.19.patch
@@ -1,7 +1,7 @@
-From 705c19e8532da3bed7284eab3dc08ccd1c2e64b8 Mon Sep 17 00:00:00 2001
+From e114448356ffdeeb6836de5f3ff0090c048bfded Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 18 Nov 2022 16:46:01 +0100
-Subject: [PATCH 13/14] bcm-knet: update API for kernel 5.19
+Subject: [PATCH 13/19] bcm-knet: update API for kernel 5.19
 
 Update kernel API usage for 5.18 and 5.19:
 
@@ -18,7 +18,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 14 insertions(+), 2 deletions(-)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-index 3abacd4a1f1e..d5b3338d7c26 100755
+index 3abacd4a1f1e..d8e14f9da5c8 100755
 --- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -302,6 +302,18 @@ static int napi_weight = 0;
@@ -59,5 +59,5 @@ index 3abacd4a1f1e..d5b3338d7c26 100755
      return 0;
  }
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0014-linux-kernel-bde-use-platform_get_irq.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0014-linux-kernel-bde-use-platform_get_irq.patch
@@ -1,7 +1,7 @@
-From 9a144ef3b6d4b6695edbcabfa6c40b02a641f910 Mon Sep 17 00:00:00 2001
+From 47dd8fdad6aa4d644c4358506130cecad2eb266a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 21 Nov 2022 12:01:36 +0100
-Subject: [PATCH 14/14] linux-kernel-bde: use platform_get_irq()
+Subject: [PATCH 14/19] linux-kernel-bde: use platform_get_irq()
 
 The Kernel stopped providing platform resources for IRQs of device tree
 backed platform devices[1], and instead requires calling
@@ -41,5 +41,5 @@ index 1c778e5be06b..65d2b1aee410 100644
  
      ctrl->isr = NULL;
 -- 
-2.38.1
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0015-bcm-knet-extract-and-update-DSCP-for-IP-packets.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0015-bcm-knet-extract-and-update-DSCP-for-IP-packets.patch
@@ -1,7 +1,7 @@
-From e7b7f050d9b9dfe58134a0b67aa107ebee9fb6eb Mon Sep 17 00:00:00 2001
+From 35a5b11b6a3e79488c9278454a410bffe81e6b66 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 6 May 2024 11:25:49 +0200
-Subject: [PATCH] bcm-knet: extract and update DSCP for IP packets
+Subject: [PATCH 15/19] bcm-knet: extract and update DSCP for IP packets
 
 For currently unknown reasons the Broadcom ASIC does not update the DSCP
 field for packets sent to controller. But the DMA header does have the
@@ -14,7 +14,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  1 file changed, 76 insertions(+)
 
 diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
-index 1e5436702cf3..3b22016c047c 100755
+index d8e14f9da5c8..7834cdb29852 100755
 --- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 +++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
 @@ -68,6 +68,7 @@
@@ -25,7 +25,7 @@ index 1e5436702cf3..3b22016c047c 100755
  
  MODULE_AUTHOR("Broadcom Corporation");
  MODULE_DESCRIPTION("Network Device Driver for Broadcom BCM TxRx API");
-@@ -2139,6 +2140,77 @@ bkn_pkt_is_rx_untagged(bkn_switch_info_t *sinfo, uint32_t *meta)
+@@ -2151,6 +2152,77 @@ bkn_pkt_is_rx_untagged(bkn_switch_info_t *sinfo, uint32_t *meta)
      }
  }
  
@@ -103,7 +103,7 @@ index 1e5436702cf3..3b22016c047c 100755
  static bkn_switch_info_t *
  bkn_sinfo_from_unit(int unit)
  {
-@@ -3909,6 +3981,8 @@ bkn_do_api_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+@@ -3921,6 +3993,8 @@ bkn_do_api_rx(bkn_switch_info_t *sinfo, int chan, int budget)
                          }
                      }
  
@@ -112,7 +112,7 @@ index 1e5436702cf3..3b22016c047c 100755
                      skb_copy_to_linear_data(skb, pkt, pktlen);
                      if (device_is_sand(sinfo)) {
                          /* CRC has been stripped */
-@@ -4362,6 +4436,8 @@ bkn_do_skb_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+@@ -4374,6 +4448,8 @@ bkn_do_skb_rx(bkn_switch_info_t *sinfo, int chan, int budget)
                          }
                      }
  
@@ -122,5 +122,5 @@ index 1e5436702cf3..3b22016c047c 100755
                          rx_cb_meta = sand_scratch_data;
                      } else {
 -- 
-2.44.0
+2.49.0
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0016-bcm-knet-fix-reported-tx-bytes.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0016-bcm-knet-fix-reported-tx-bytes.patch
@@ -1,0 +1,33 @@
+From abbde684f9f07dcc932ef89833291fdb05727f47 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Wed, 14 May 2025 15:47:49 +0200
+Subject: [PATCH 16/19] bcm-knet: fix reported tx bytes
+
+Do not include FCS and custom data header in tx byte counts. The custom
+header is never transmitted on the wire and consumed by the ASIC, so we
+should not count it, and we do not count it for rx bytes.
+
+Likewise, rx and tx bytes should exclude the FCS, so we need to
+substract it here as well.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+index 7834cdb29852..0dac8ec479d9 100755
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+@@ -6433,7 +6433,7 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+         }
+ 
+         priv->stats.tx_packets++;
+-        priv->stats.tx_bytes += pktlen;
++        priv->stats.tx_bytes += (pktlen - 4 - hdrlen);
+         sinfo->tx.pkts++;
+     } else {
+         DBG_VERB(("Tx busy: No DMA resources\n"));
+-- 
+2.49.0
+

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0017-bcm-knet-switch-to-stat64.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0017-bcm-knet-switch-to-stat64.patch
@@ -1,0 +1,395 @@
+From e955bc42216610a7f6b172c8b6036d286d180a3f Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Wed, 14 May 2025 10:48:41 +0200
+Subject: [PATCH 17/19] bcm-knet: switch to stat64
+
+In preparation to report accurate counts, switch to stat64. This has no
+effect on 64 bit, but for 32 bit this switches to 64 bit counters. Since
+64 bit values cannot be written atomically, make use of u64_stat_sync
+helpers.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 140 +++++++++++++-----
+ 1 file changed, 106 insertions(+), 34 deletions(-)
+
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+index 0dac8ec479d9..0c2b6c5fa65b 100755
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+@@ -67,6 +67,7 @@
+ #include <linux/seq_file.h>
+ #include <linux/if_vlan.h>
+ #include <linux/nsproxy.h>
++#include <linux/u64_stats_sync.h>
+ 
+ #include <net/dsfield.h>
+ 
+@@ -954,9 +955,20 @@ static u8 bkn_rcpu_smac[6];
+ /* Driver Proc Entry root */
+ static struct proc_dir_entry *bkn_proc_root = NULL;
+ 
++typedef struct bkn_stats_s {
++    struct u64_stats_sync syncp;
++    u64_stats_t rx_packets;
++    u64_stats_t tx_packets;
++    u64_stats_t rx_bytes;
++    u64_stats_t tx_bytes;
++    u64_stats_t rx_errors;
++    u64_stats_t rx_dropped;
++    u64_stats_t tx_dropped;
++} bkn_stats_t;
++
+ typedef struct bkn_priv_s {
+     struct list_head list;
+-    struct net_device_stats stats;
++    bkn_stats_t stats;
+     struct net_device *dev;
+     bkn_switch_info_t *sinfo;
+     int id;
+@@ -3760,6 +3772,7 @@ bkn_do_api_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+     int dcbs_done = 0;
+     bkn_dune_system_header_info_t packet_info;
+     uint32_t sand_scratch_data[BKN_SAND_SCRATCH_DATA_SIZE] = {0};
++    unsigned long flags;
+ 
+     dcb_chain = sinfo->rx[chan].api_dcb_chain;
+     if (dcb_chain == NULL) {
+@@ -4002,8 +4015,10 @@ bkn_do_api_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+                     } else {
+                         skb_put(skb, pktlen - 4); /* Strip CRC */
+                     }
+-                    priv->stats.rx_packets++;
+-                    priv->stats.rx_bytes += skb->len;
++                    flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                    u64_stats_inc(&priv->stats.rx_packets);
++                    u64_stats_add(&priv->stats.rx_bytes, skb->len);
++                    u64_stats_update_end_irqrestore(&priv->stats.syncp, flags);
+ 
+                     /* Optional SKB updates */
+                     KNET_SKB_CB(skb)->dcb_type = sinfo->dcb_type & 0xFFFF;
+@@ -4108,6 +4123,7 @@ bkn_skb_rx_netif_process(bkn_switch_info_t *sinfo, int dest_id, int chan,
+                          int pkt_hdr_size, int pktlen, int ethertype)
+ {
+     bkn_priv_t *priv;
++    unsigned long flags;
+ 
+     DBG_VERB(("Process SKB to netif %d\n", dest_id));
+     priv = bkn_netif_lookup(sinfo, dest_id);
+@@ -4137,8 +4153,10 @@ bkn_skb_rx_netif_process(bkn_switch_info_t *sinfo, int dest_id, int chan,
+         }
+     }
+ 
+-    priv->stats.rx_packets++;
+-    priv->stats.rx_bytes += skb->len;
++    flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++    u64_stats_inc(&priv->stats.rx_packets);
++    u64_stats_add(&priv->stats.rx_bytes, skb->len);
++    u64_stats_update_end_irqrestore(&priv->stats.syncp, flags);
+     skb->dev = priv->dev;
+ 
+     if (knet_rx_cb != NULL) {
+@@ -4148,7 +4166,9 @@ bkn_skb_rx_netif_process(bkn_switch_info_t *sinfo, int dest_id, int chan,
+         if (skb == NULL) {
+             /* Consumed by call-back */
+             sinfo->rx[chan].pkts_d_callback++;
+-            priv->stats.rx_dropped++;
++            flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++            u64_stats_inc(&priv->stats.rx_dropped);
++            u64_stats_update_end_irqrestore(&priv->stats.syncp, flags);
+             return -1;
+         }
+     }
+@@ -4197,6 +4217,7 @@ bkn_do_skb_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+     bkn_priv_t *mpriv;
+     struct sk_buff *mskb = NULL;
+     uint32_t *rx_cb_meta;
++    unsigned long flags;
+ 
+     if (!sinfo->rx[chan].running) {
+         /* Rx not ready */
+@@ -4351,7 +4372,9 @@ bkn_do_skb_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+ 
+             if ((dcb[sinfo->dcb_wsize-1] & 0xf0000) != 0x30000) {
+                 /* Fragment or error */
+-                priv->stats.rx_errors++;
++                flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                u64_stats_inc(&priv->stats.rx_errors);
++                u64_stats_update_end_irqrestore(&priv->stats.syncp, flags);
+                 if (filter && filter->kf.mask.w[err_woff] == 0) {
+                     /* Drop unless DCB status is part of filter */
+                     filter = NULL;
+@@ -4508,8 +4531,10 @@ bkn_do_skb_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+                                 if (mskb == NULL) {
+                                     sinfo->rx[chan].pkts_d_no_skb++;
+                                 } else {
+-                                    mpriv->stats.rx_packets++;
+-                                    mpriv->stats.rx_bytes += mskb->len;
++                                    flags = u64_stats_update_begin_irqsave(&mpriv->stats.syncp);
++                                    u64_stats_inc(&mpriv->stats.rx_packets);
++                                    u64_stats_add(&mpriv->stats.rx_bytes, mskb->len);
++                                    u64_stats_update_end_irqrestore(&mpriv->stats.syncp, flags);
+                                     mskb->dev = mpriv->dev;
+                                     if (filter->kf.mirror_proto) {
+                                         mskb->protocol = filter->kf.mirror_proto;
+@@ -4579,7 +4604,9 @@ bkn_do_skb_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+         } else {
+             DBG_PKT(("Rx packet dropped.\n"));
+             sinfo->rx[chan].pkts_d_no_match++;
+-            priv->stats.rx_dropped++;
++            flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++            u64_stats_inc(&priv->stats.rx_dropped);
++            u64_stats_update_end_irqrestore(&priv->stats.syncp, flags);
+         }
+         dcb[sinfo->dcb_wsize-1] &= ~(1 << 31);
+         if (++sinfo->rx[chan].dirty >= MAX_RX_DCBS) {
+@@ -5795,12 +5822,22 @@ bkn_stop(struct net_device *dev)
+  * Network Device Statistics.
+  * Cleared at init time.
+  */
+-static struct net_device_stats *
+-bkn_get_stats(struct net_device *dev)
++static void
++bkn_get_stats64(struct net_device *dev, struct rtnl_link_stats64 *storage)
+ {
+     bkn_priv_t *priv = netdev_priv(dev);
++    unsigned int start;
+ 
+-    return &priv->stats;
++    do {
++        start = u64_stats_fetch_begin(&priv->stats.syncp);
++        storage->rx_packets = u64_stats_read(&priv->stats.rx_packets);
++        storage->tx_packets = u64_stats_read(&priv->stats.tx_packets);
++        storage->rx_bytes = u64_stats_read(&priv->stats.rx_bytes);
++        storage->tx_bytes = u64_stats_read(&priv->stats.tx_bytes);
++        storage->rx_errors = u64_stats_read(&priv->stats.rx_errors);
++        storage->rx_dropped = u64_stats_read(&priv->stats.rx_dropped);
++        storage->tx_dropped = u64_stats_read(&priv->stats.tx_dropped);
++    } while (u64_stats_fetch_retry(&priv->stats.syncp, start));
+ }
+ 
+ /* Fake multicast ability */
+@@ -5869,7 +5906,7 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+     int sop, idx;
+     uint16_t tpid;
+     uint32_t *metadata;
+-    unsigned long flags;
++    unsigned long flags, stats_flags;
+     uint8_t cpu_channel = 0;
+     int headroom, tailroom;
+ 
+@@ -5877,20 +5914,26 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+ 
+     if (priv->id <= 0) {
+         /* Do not transmit on base device */
+-        priv->stats.tx_dropped++;
++        stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++        u64_stats_inc(&priv->stats.tx_dropped);
++        u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+         dev_kfree_skb_any(skb);
+         return 0;
+     }
+ 
+     if (device_is_dnx(sinfo) && (skb->len == 0)) {
+-        priv->stats.tx_dropped++;
++        stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++        u64_stats_inc(&priv->stats.tx_dropped);
++        u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+         dev_kfree_skb_any(skb);
+         return 0;
+     }
+ 
+     if (!netif_carrier_ok(dev)) {
+         DBG_WARN(("Tx drop: Netif link is down.\n"));
+-        priv->stats.tx_dropped++;
++        stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++        u64_stats_inc(&priv->stats.tx_dropped);
++        u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+         sinfo->tx.pkts_d_no_link++;
+         dev_kfree_skb_any(skb);
+         return 0;
+@@ -5926,7 +5969,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+             rcpulen = RCPU_HDR_SIZE;
+             if (skb->len < (rcpulen + 14)) {
+                 DBG_WARN(("Tx drop: Invalid RCPU encapsulation\n"));
+-                priv->stats.tx_dropped++;
++                stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                u64_stats_inc(&priv->stats.tx_dropped);
++                u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                 sinfo->tx.pkts_d_rcpu_encap++;
+                 dev_kfree_skb_any(skb);
+                 spin_unlock_irqrestore(&sinfo->lock, flags);
+@@ -5935,7 +5980,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+             if (check_rcpu_signature &&
+                 PKT_U16_GET(skb->data, 18) != sinfo->rcpu_sig) {
+                 DBG_WARN(("Tx drop: Invalid RCPU signature\n"));
+-                priv->stats.tx_dropped++;
++                stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                u64_stats_inc(&priv->stats.tx_dropped);
++                u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                 sinfo->tx.pkts_d_rcpu_sig++;
+                 dev_kfree_skb_any(skb);
+                 spin_unlock_irqrestore(&sinfo->lock, flags);
+@@ -5959,7 +6006,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+                     break;
+                 default:
+                     DBG_WARN(("Tx drop: Invalid RCPU meta data\n"));
+-                    priv->stats.tx_dropped++;
++                    stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                    u64_stats_inc(&priv->stats.tx_dropped);
++                    u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                     sinfo->tx.pkts_d_rcpu_meta++;
+                     dev_kfree_skb_any(skb);
+                     spin_unlock_irqrestore(&sinfo->lock, flags);
+@@ -5968,7 +6017,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+                 if (sinfo->cmic_type != 'x') {
+                     if (skb->len < (rcpulen + RCPU_TX_META_SIZE + 14)) {
+                         DBG_WARN(("Tx drop: Invalid RCPU encapsulation\n"));
+-                        priv->stats.tx_dropped++;
++                        stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                        u64_stats_inc(&priv->stats.tx_dropped);
++                        u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                         sinfo->tx.pkts_d_rcpu_encap++;
+                         dev_kfree_skb_any(skb);
+                         spin_unlock_irqrestore(&sinfo->lock, flags);
+@@ -6007,7 +6058,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+                                                       GFP_ATOMIC);
+                             if (new_skb == NULL) {
+                                 DBG_WARN(("Tx drop: No SKB memory\n"));
+-                                priv->stats.tx_dropped++;
++                                stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                                u64_stats_inc(&priv->stats.tx_dropped);
++                                u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                                 sinfo->tx.pkts_d_no_skb++;
+                                 dev_kfree_skb_any(skb);
+                                 spin_unlock_irqrestore(&sinfo->lock, flags);
+@@ -6059,7 +6112,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+                                               GFP_ATOMIC);
+                     if (new_skb == NULL) {
+                         DBG_WARN(("Tx drop: No SKB memory\n"));
+-                        priv->stats.tx_dropped++;
++                        stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                        u64_stats_inc(&priv->stats.tx_dropped);
++                        u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                         sinfo->tx.pkts_d_no_skb++;
+                         dev_kfree_skb_any(skb);
+                         spin_unlock_irqrestore(&sinfo->lock, flags);
+@@ -6096,7 +6151,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+                                                   GFP_ATOMIC);
+                         if (new_skb == NULL) {
+                             DBG_WARN(("Tx drop: No SKB memory\n"));
+-                            priv->stats.tx_dropped++;
++                            stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                            u64_stats_inc(&priv->stats.tx_dropped);
++                            u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                             sinfo->tx.pkts_d_no_skb++;
+                             dev_kfree_skb_any(skb);
+                             spin_unlock_irqrestore(&sinfo->lock, flags);
+@@ -6135,7 +6192,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+             pktlen = (60 + taglen + hdrlen);
+             if (SKB_PADTO(skb, pktlen) != 0) {
+                 DBG_WARN(("Tx drop: skb_padto failed\n"));
+-                priv->stats.tx_dropped++;
++                stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                u64_stats_inc(&priv->stats.tx_dropped);
++                u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                 sinfo->tx.pkts_d_pad_fail++;
+                 dev_kfree_skb_any(skb);
+                 spin_unlock_irqrestore(&sinfo->lock, flags);
+@@ -6149,7 +6208,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+             DBG_WARN(("Tx drop: size of pkt (%d) is out of range(%d)\n",
+                      (pktlen + FCS_SZ), SOC_DCB_KNET_COUNT_MASK));
+             sinfo->tx.pkts_d_over_limit++;
+-            priv->stats.tx_dropped++;
++            stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++            u64_stats_inc(&priv->stats.tx_dropped);
++            u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+             dev_kfree_skb_any(skb);
+             spin_unlock_irqrestore(&sinfo->lock, flags);
+             return 0;
+@@ -6309,7 +6370,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+             if (skb == NULL) {
+                 /* Consumed by call-back */
+                 DBG_WARN(("Tx drop: Consumed by call-back\n"));
+-                priv->stats.tx_dropped++;
++                stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                u64_stats_inc(&priv->stats.tx_dropped);
++                u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                 sinfo->tx.pkts_d_callback++;
+                 spin_unlock_irqrestore(&sinfo->lock, flags);
+                 return 0;
+@@ -6323,7 +6386,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+                     pktlen = (60 + taglen + hdrlen);
+                     if (SKB_PADTO(skb, pktlen) != 0) {
+                         DBG_WARN(("Tx drop: skb_padto failed\n"));
+-                        priv->stats.tx_dropped++;
++                        stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                        u64_stats_inc(&priv->stats.tx_dropped);
++                        u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                         sinfo->tx.pkts_d_pad_fail++;
+                         dev_kfree_skb_any(skb);
+                         spin_unlock_irqrestore(&sinfo->lock, flags);
+@@ -6339,7 +6404,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+                 DBG_WARN(("Tx drop: size of pkt (%d) is out of range(%d)\n",
+                          (pktlen + FCS_SZ), SOC_DCB_KNET_COUNT_MASK));
+                 sinfo->tx.pkts_d_over_limit++;
+-                priv->stats.tx_dropped++;
++                stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++                u64_stats_inc(&priv->stats.tx_dropped);
++                u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+                 sinfo->tx.pkts_d_callback++;
+                 dev_kfree_skb_any(skb);
+                 spin_unlock_irqrestore(&sinfo->lock, flags);
+@@ -6391,7 +6458,9 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+                                        pktdata, desc->dma_size,
+                                        BKN_DMA_TODEV);
+         if (BKN_DMA_MAPPING_ERROR(sinfo->dma_dev, desc->skb_dma)) {
+-            priv->stats.tx_dropped++;
++            stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++            u64_stats_inc(&priv->stats.tx_dropped);
++            u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+             dev_kfree_skb_any(skb);
+             spin_unlock_irqrestore(&sinfo->lock, flags);
+             return 0;
+@@ -6432,8 +6501,10 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
+                           sinfo->tx.desc[sinfo->tx.cur].dcb_dma);
+         }
+ 
+-        priv->stats.tx_packets++;
+-        priv->stats.tx_bytes += (pktlen - 4 - hdrlen);
++        stats_flags = u64_stats_update_begin_irqsave(&priv->stats.syncp);
++        u64_stats_inc(&priv->stats.tx_packets);
++        u64_stats_add(&priv->stats.tx_bytes, pktlen - 4 - hdrlen);
++        u64_stats_update_end_irqrestore(&priv->stats.syncp, stats_flags);
+         sinfo->tx.pkts++;
+     } else {
+         DBG_VERB(("Tx busy: No DMA resources\n"));
+@@ -6730,7 +6801,7 @@ static const struct net_device_ops bkn_netdev_ops = {
+     .ndo_open            = bkn_open,
+     .ndo_stop            = bkn_stop,
+     .ndo_start_xmit      = bkn_tx,
+-    .ndo_get_stats       = bkn_get_stats,
++    .ndo_get_stats64     = bkn_get_stats64,
+     .ndo_validate_addr   = eth_validate_addr,
+     .ndo_set_rx_mode     = bkn_set_multicast_list,
+     .ndo_set_mac_address = eth_mac_addr,
+@@ -6914,7 +6985,6 @@ bkn_init_ndev(u8 *mac, char *name)
+     dev->stop = bkn_stop;
+     dev->set_multicast_list = bkn_set_multicast_list;
+     dev->do_ioctl = NULL;
+-    dev->get_stats = bkn_get_stats;
+     dev->change_mtu = bkn_change_mtu;
+ #ifdef CONFIG_NET_POLL_CONTROLLER
+     dev->poll_controller = bkn_poll_controller;
+@@ -6928,6 +6998,8 @@ bkn_init_ndev(u8 *mac, char *name)
+         strncpy(dev->name, name, IFNAMSIZ-1);
+     }
+ 
++    u64_stats_init(&priv->stats.syncp);
++
+     bkn_dev_net_set(dev, current->nsproxy->net_ns);
+ 
+     DBG_VERB(("Created Ethernet device %s.\n", dev->name));
+-- 
+2.49.0
+

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0018-kcom-add-a-message-for-pushing-hw-counters-to-netifs.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0018-kcom-add-a-message-for-pushing-hw-counters-to-netifs.patch
@@ -1,0 +1,87 @@
+From 63cff5d34b4a27c1aeb7c45d4a9e75b0cfb4e536 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Thu, 15 May 2025 11:39:24 +0200
+Subject: [PATCH 18/19] kcom: add a message for pushing hw counters to netifs
+
+In order to expose hw counters directly on knet interfaces, add a
+message to push them out.
+
+For now only use a subset of counters to keep the size reasonable,
+selected by matching the available counters [1] to rtnl_link_stats64
+from the kernel [2].
+
+[1] https://github.com/Broadcom-Network-Switching-Software/OpenBCM/blob/master/sdk-6.5.24/include/bcm/stat.h
+[2] https://elixir.bootlin.com/linux/v6.6.90/source/include/uapi/linux/if_link.h#L42
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ sdk-6.5.24/include/kcom.h | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+diff --git a/sdk-6.5.24/include/kcom.h b/sdk-6.5.24/include/kcom.h
+index 028a2c771a4e..07a0618154ac 100755
+--- a/sdk-6.5.24/include/kcom.h
++++ b/sdk-6.5.24/include/kcom.h
+@@ -50,6 +50,8 @@
+ 
+ #define KCOM_VERSION            13 /* Protocol version */
+ 
++#define KCOM_M_NETIF_STATS	128 /* Netif stats */
++
+ /*
+  * Message status codes
+  */
+@@ -347,6 +349,26 @@ typedef struct kcom_clock_info_s {
+     int32 data[8];
+ } kcom_clock_info_t;
+ 
++typedef struct kcom_netif_stats_s {
++    uint64 port_in_frames;
++    uint64 port_out_frames;
++    uint64 if_in_octets;
++    uint64 if_out_octets;
++    uint64 if_in_errors;
++    uint64 if_out_errors;
++    uint64 if_in_discards;
++    uint64 if_out_discards;
++    uint64 if_in_mcast_packets;
++    uint64 if_collisions;
++    uint64 dot3_in_range_length_errors;
++    uint64 dot3_frame_too_long_errors;
++    uint64 dot3_fcs_errors;
++    uint64 dot3_alignment_errors;
++    uint64 dot3_carrier_sense_errors;
++    uint64 dot3_sqe_test_errors;
++    uint64 dot3_late_collisions;
++} kcom_netif_stats_t;
++
+ /*
+  * Send literal string to/from kernel module.
+  * Mainly for debugging purposes.
+@@ -554,6 +576,15 @@ typedef struct kcom_msg_hw_info_s {
+     kcom_oamp_info_t oamp_info;
+ } kcom_msg_hw_info_t;
+ 
++/*
++ * Netif stats
++ */
++
++typedef struct kcom_msg_netif_stats_s {
++    kcom_msg_hdr_t hdr;
++    kcom_netif_stats_t netif_stats;
++} kcom_msg_netif_stats_t;
++
+ /*
+  * All messages (e.g. for generic receive)
+  */
+@@ -580,6 +611,7 @@ typedef union kcom_msg_s {
+     kcom_msg_dbg_pkt_get_t dbg_pkt_get;
+     kcom_msg_wb_cleanup_t wb_cleanup;
+     kcom_msg_clock_cmd_t clock_cmd;
++    kcom_msg_netif_stats_t netif_stats;
+ } kcom_msg_t;
+ 
+ /*
+-- 
+2.49.0
+

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0019-bcm-knet-expose-hw-counters-on-port-netifs.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0019-bcm-knet-expose-hw-counters-on-port-netifs.patch
@@ -1,0 +1,245 @@
+From a1469e8668746b1382a4b045844c3eeae88fbff2 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Thu, 15 May 2025 11:56:06 +0200
+Subject: [PATCH 19/19] bcm-knet: expose hw counters on port netifs
+
+Now that we can we have a message for updating hw counters on netifs,
+handle in in the kernel driver and expose them as regular stats on port
+type netifs.
+
+Since the software counters are still interesting, delegate them to
+IFLA_OFFLOAD_XSTATS_CPU_HIT type offload stats, which seem to be the
+most appropriate.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 175 +++++++++++++++++-
+ 1 file changed, 165 insertions(+), 10 deletions(-)
+
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+index 0c2b6c5fa65b..6da8262aeca0 100755
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+@@ -966,9 +966,31 @@ typedef struct bkn_stats_s {
+     u64_stats_t tx_dropped;
+ } bkn_stats_t;
+ 
++typedef struct bkn_hw_stats_s {
++    struct u64_stats_sync syncp;
++    u64_stats_t port_in_frames;
++    u64_stats_t port_out_frames;
++    u64_stats_t if_in_octets;
++    u64_stats_t if_out_octets;
++    u64_stats_t if_in_errors;
++    u64_stats_t if_out_errors;
++    u64_stats_t if_in_discards;
++    u64_stats_t if_out_discards;
++    u64_stats_t if_in_mcast_packets;
++    u64_stats_t if_collisions;
++    u64_stats_t dot3_in_range_length_errors;
++    u64_stats_t dot3_frame_too_long_errors;
++    u64_stats_t dot3_fcs_errors;
++    u64_stats_t dot3_alignment_errors;
++    u64_stats_t dot3_carrier_sense_errors;
++    u64_stats_t dot3_sqe_test_errors;
++    u64_stats_t dot3_late_collisions;
++} bkn_hw_stats_t;
++
+ typedef struct bkn_priv_s {
+     struct list_head list;
+     bkn_stats_t stats;
++    bkn_hw_stats_t hw_stats;
+     struct net_device *dev;
+     bkn_switch_info_t *sinfo;
+     int id;
+@@ -5828,16 +5850,86 @@ bkn_get_stats64(struct net_device *dev, struct rtnl_link_stats64 *storage)
+     bkn_priv_t *priv = netdev_priv(dev);
+     unsigned int start;
+ 
+-    do {
+-        start = u64_stats_fetch_begin(&priv->stats.syncp);
+-        storage->rx_packets = u64_stats_read(&priv->stats.rx_packets);
+-        storage->tx_packets = u64_stats_read(&priv->stats.tx_packets);
+-        storage->rx_bytes = u64_stats_read(&priv->stats.rx_bytes);
+-        storage->tx_bytes = u64_stats_read(&priv->stats.tx_bytes);
+-        storage->rx_errors = u64_stats_read(&priv->stats.rx_errors);
+-        storage->rx_dropped = u64_stats_read(&priv->stats.rx_dropped);
+-        storage->tx_dropped = u64_stats_read(&priv->stats.tx_dropped);
+-    } while (u64_stats_fetch_retry(&priv->stats.syncp, start));
++    if (priv->type == KCOM_NETIF_T_PORT) {
++        do {
++            start = u64_stats_fetch_begin(&priv->hw_stats.syncp);
++            storage->rx_packets = u64_stats_read(&priv->hw_stats.port_in_frames);
++            storage->tx_packets = u64_stats_read(&priv->hw_stats.port_out_frames);
++            storage->rx_bytes = u64_stats_read(&priv->hw_stats.if_in_octets);
++            /* substract fcs */
++            storage->rx_bytes -= storage->rx_packets * 4;
++            storage->tx_bytes = u64_stats_read(&priv->hw_stats.if_out_octets);
++            /* substract fcs */
++            storage->tx_bytes -= storage->tx_packets * 4;
++            storage->rx_errors = u64_stats_read(&priv->hw_stats.if_in_errors);
++            storage->tx_errors = u64_stats_read(&priv->hw_stats.if_out_errors);
++            storage->rx_dropped = u64_stats_read(&priv->hw_stats.if_in_discards);
++            storage->tx_dropped = u64_stats_read(&priv->hw_stats.if_out_discards);
++            storage->multicast = u64_stats_read(&priv->hw_stats.if_in_mcast_packets);
++            storage->rx_length_errors = u64_stats_read(&priv->hw_stats.dot3_in_range_length_errors) +
++                                        u64_stats_read(&priv->hw_stats.dot3_frame_too_long_errors);
++            storage->rx_crc_errors = u64_stats_read(&priv->hw_stats.dot3_fcs_errors);
++            storage->rx_frame_errors = u64_stats_read(&priv->hw_stats.dot3_alignment_errors);
++            storage->tx_carrier_errors = u64_stats_read(&priv->hw_stats.dot3_carrier_sense_errors);
++            storage->tx_heartbeat_errors = u64_stats_read(&priv->hw_stats.dot3_sqe_test_errors);
++            storage->tx_window_errors = u64_stats_read(&priv->hw_stats.dot3_late_collisions);
++        } while (u64_stats_fetch_retry(&priv->hw_stats.syncp, start));
++    } else {
++        do {
++            start = u64_stats_fetch_begin(&priv->stats.syncp);
++            storage->rx_packets = u64_stats_read(&priv->stats.rx_packets);
++            storage->tx_packets = u64_stats_read(&priv->stats.tx_packets);
++            storage->rx_bytes = u64_stats_read(&priv->stats.rx_bytes);
++            storage->tx_bytes = u64_stats_read(&priv->stats.tx_bytes);
++            storage->rx_errors = u64_stats_read(&priv->stats.rx_errors);
++            storage->rx_dropped = u64_stats_read(&priv->stats.rx_dropped);
++            storage->tx_dropped = u64_stats_read(&priv->stats.tx_dropped);
++        } while (u64_stats_fetch_retry(&priv->stats.syncp, start));
++    }
++}
++
++static bool
++bkn_has_offload_stats(const struct net_device *dev, int attr_id)
++{
++    bkn_priv_t *priv = netdev_priv(dev);
++
++    if (priv->type != KCOM_NETIF_T_PORT)
++        return false;
++
++    switch (attr_id) {
++    case IFLA_OFFLOAD_XSTATS_CPU_HIT:
++        return true;
++    }
++
++    return false;
++}
++
++static int
++bkn_get_offload_stats(int attr_id, const struct net_device *dev, void *attr_data)
++{
++    struct rtnl_link_stats64 *storage = (struct rtnl_link_stats64 *)attr_data;
++    bkn_priv_t *priv = netdev_priv(dev);
++    unsigned int start;
++
++    if (priv->type != KCOM_NETIF_T_PORT)
++        return -EINVAL;
++
++    switch (attr_id) {
++    case IFLA_OFFLOAD_XSTATS_CPU_HIT:
++        do {
++            start = u64_stats_fetch_begin(&priv->stats.syncp);
++            storage->rx_packets = u64_stats_read(&priv->stats.rx_packets);
++            storage->tx_packets = u64_stats_read(&priv->stats.tx_packets);
++            storage->rx_bytes = u64_stats_read(&priv->stats.rx_bytes);
++            storage->tx_bytes = u64_stats_read(&priv->stats.tx_bytes);
++            storage->rx_errors = u64_stats_read(&priv->stats.rx_errors);
++            storage->rx_dropped = u64_stats_read(&priv->stats.rx_dropped);
++            storage->tx_dropped = u64_stats_read(&priv->stats.tx_dropped);
++        } while (u64_stats_fetch_retry(&priv->stats.syncp, start));
++        return 0;
++    }
++
++    return -EINVAL;
+ }
+ 
+ /* Fake multicast ability */
+@@ -6802,6 +6894,8 @@ static const struct net_device_ops bkn_netdev_ops = {
+     .ndo_stop            = bkn_stop,
+     .ndo_start_xmit      = bkn_tx,
+     .ndo_get_stats64     = bkn_get_stats64,
++    .ndo_has_offload_stats = bkn_has_offload_stats,
++    .ndo_get_offload_stats = bkn_get_offload_stats,
+     .ndo_validate_addr   = eth_validate_addr,
+     .ndo_set_rx_mode     = bkn_set_multicast_list,
+     .ndo_set_mac_address = eth_mac_addr,
+@@ -6999,6 +7093,7 @@ bkn_init_ndev(u8 *mac, char *name)
+     }
+ 
+     u64_stats_init(&priv->stats.syncp);
++    u64_stats_init(&priv->hw_stats.syncp);
+ 
+     bkn_dev_net_set(dev, current->nsproxy->net_ns);
+ 
+@@ -9337,6 +9432,61 @@ bkn_knet_wb_cleanup(kcom_msg_wb_cleanup_t *kmsg, int len)
+     return sizeof(kcom_msg_hdr_t);
+ }
+ 
++static int
++bkn_knet_netif_stats(kcom_msg_netif_stats_t *kmsg, int len)
++{
++    unsigned long flags, stat_flags;
++    bkn_switch_info_t *sinfo;
++    bkn_priv_t *priv;
++
++    kmsg->hdr.type = KCOM_MSG_TYPE_RSP;
++
++    sinfo = bkn_sinfo_from_unit(kmsg->hdr.unit);
++    if (sinfo == NULL) {
++        kmsg->hdr.status = KCOM_E_PARAM;
++        return sizeof(kcom_msg_hdr_t);
++    }
++
++    spin_lock_irqsave(&sinfo->lock, flags);
++
++    priv = bkn_netif_lookup(sinfo, kmsg->hdr.id);
++
++    if (priv == NULL) {
++        spin_unlock_irqrestore(&sinfo->lock, flags);
++        kmsg->hdr.status = KCOM_E_NOT_FOUND;
++        return sizeof(kcom_msg_hdr_t);
++    }
++
++#define COPY_COUNTER(dst, src, counter) \
++    u64_stats_set(&(dst).counter, (src).counter)
++
++    stat_flags = u64_stats_update_begin_irqsave(&priv->hw_stats.syncp);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, port_in_frames);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, port_out_frames);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, if_in_octets);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, if_out_octets);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, if_in_errors);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, if_out_errors);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, if_in_discards);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, if_out_discards);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, if_in_mcast_packets);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, if_collisions);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, dot3_in_range_length_errors);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, dot3_frame_too_long_errors);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, dot3_fcs_errors);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, dot3_alignment_errors);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, dot3_carrier_sense_errors);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, dot3_sqe_test_errors);
++    COPY_COUNTER(priv->hw_stats, kmsg->netif_stats, dot3_late_collisions);
++    u64_stats_update_end_irqrestore(&priv->hw_stats.syncp, stat_flags);
++
++#undef COPY_COUNTER
++
++    spin_unlock_irqrestore(&sinfo->lock, flags);
++
++    return sizeof(kcom_msg_hdr_t);
++}
++
+ static int
+ bkn_handle_cmd_req(kcom_msg_t *kmsg, int len)
+ {
+@@ -9460,6 +9610,11 @@ bkn_handle_cmd_req(kcom_msg_t *kmsg, int len)
+             len = sizeof(kcom_msg_hdr_t);
+         }
+         break;
++     case KCOM_M_NETIF_STATS:
++        DBG_CMD(("KCOM_M_WB_CLEANUP\n"));
++        /* Update netif hardware counters */
++        len = bkn_knet_netif_stats(&kmsg->netif_stats, len);
++        break;
+     default:
+         DBG_WARN(("Unsupported command (type=%d, opcode=%d)\n",
+                   kmsg->hdr.type, kmsg->hdr.opcode));
+-- 
+2.49.0
+

--- a/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
+++ b/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
@@ -27,6 +27,10 @@ SRC_URI = " \
           file://patches/0013-bcm-knet-update-API-for-kernel-5.19.patch;striplevel=2 \
           file://patches/0014-linux-kernel-bde-use-platform_get_irq.patch;striplevel=2 \
           file://patches/0015-bcm-knet-extract-and-update-DSCP-for-IP-packets.patch;striplevel=2 \
+          file://patches/0016-bcm-knet-fix-reported-tx-bytes.patch;striplevel=2 \
+          file://patches/0017-bcm-knet-switch-to-stat64.patch;striplevel=2 \
+          file://patches/0018-kcom-add-a-message-for-pushing-hw-counters-to-netifs.patch;striplevel=2 \
+          file://patches/0019-bcm-knet-expose-hw-counters-on-port-netifs.patch;striplevel=2 \
           "
 
 SRC_URI:append:agema-ag7648 = " \


### PR DESCRIPTION
In order to expose hardware counters via standard interfaces, allow pushing counters via the SDK knet interface to created port interfaces.

These then get exposed via the normal counters, while the "old" software counters are now exposed as cpu_hit offload counters:

```
accton-as4610-54:~$ ip stats show dev port2
8: port2: group offload subgroup hw_stats_info
    l3_stats off used off
8: port2: group afstats subgroup mpls
8: port2: group link
    RX:  bytes packets errors dropped  missed   mcast
           340       4      0       1       0       4
    TX:  bytes packets errors dropped carrier collsns
          2578      23      0       0       0       0
8: port2: group offload subgroup l3_stats off used off
8: port2: group offload subgroup cpu_hit
    RX:  bytes packets errors dropped  missed   mcast
           250       3      0       0       0       0
    TX:  bytes packets errors dropped carrier collsns
          2578      23      0       0       0       0
8: port2: group xstats_slave subgroup bond suite 802.3ad
8: port2: group xstats subgroup bond suite 802.3ad
8: port2: group xstats_slave subgroup bridge suite mcast
8: port2: group xstats_slave subgroup bridge suite stp
8: port2: group xstats subgroup bridge suite mcast
8: port2: group xstats subgroup bridge suite stp
```

Since these counters are all 64 bit, but knet uses 32 bit counters on 32bit systems, convert knet to always use 64 bit counters to avoid (fast) overflows.

To ensure that software and hardware counters match where expected, fix up the software tx byte counters which happeneded to include the proprietary header used by the switch and fcs.