### PR TITLE
next: switch to scarthgap

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,4 +14,4 @@ LAYERVERSION_ofdpa    = "1"
 # LAYERDEPENDS_sdn    = "acceleration"
 # LAYERDEPENDS_ofdpa    = "openembedded-layer"
 
-LAYERSERIES_COMPAT_ofdpa = "kirkstone"
+LAYERSERIES_COMPAT_ofdpa = "scarthgap"


### PR DESCRIPTION
Switch meta-ofdpa to scarthgap (5.0). No changes needed apart from updating `LAYERSERIES_COMPAT`.