### PR TITLE
ofdpa(-grpc): expose bcm_rx_rate_set() 

### DIFF
--- a/recipes-extended/ofdpa-grpc/ofdpa-grpc_0.7.bb
+++ b/recipes-extended/ofdpa-grpc/ofdpa-grpc_0.7.bb
@@ -4,7 +4,7 @@ inherit systemd
 
 include ofdpa-grpc.inc
 
-SRCREV = "a323a61ca506f5b9f9691e559a2c5b833c619435"
+SRCREV = "a4de834e81cfc8b6f6767379a763650088db9faa"
 
 DEPENDS += "grpc gflags glog protobuf openssl ofdpa systemd"
 

--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -1,9 +1,9 @@
 DESCRIPTION = ""
 LICENSE = "CLOSED"
 
-PR = "r43"
+PR = "r44"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "0950c31e9629a83b916f6f138a3dd9c6899debb1"
+SRCREV_ofdpa = "4cbd127fbbf22a234590870fb64cf4bb4b92df99"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
With using KNET, rx rates higher than the default of 1024 pps are easily
achievable. To allow setting these dynamically, expose the SDK API
function as an OF-DPA API function and via gRPC.