### PR TITLE
openbcm-gpl-modules: bcm-knet: do not mark BPDU packets as forwarded

### DIFF
--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0001-gmodule-update-proc-code-for-linux-5.6.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0001-gmodule-update-proc-code-for-linux-5.6.patch
@@ -1,7 +1,7 @@
 From af0023f4e05da89fe3e46a1681f11b034fb5f8ab Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 15:55:39 +0100
-Subject: [PATCH 01/19] gmodule: update proc code for linux 5.6+
+Subject: [PATCH 01/20] gmodule: update proc code for linux 5.6+
 
 ---
  .../systems/linux/kernel/modules/shared/gmodule.c      | 10 ++++++++++
@@ -36,5 +36,5 @@ index 0635b811ed8e..55a9ffc6c350 100644
  int
  gmodule_vpprintf(char** page_ptr, const char* fmt, va_list args)
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch
@@ -1,7 +1,7 @@
 From 425a8a9adf62754df06a78e666d70db85fdcf6f8 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 16:02:44 +0100
-Subject: [PATCH 02/19] kernel-modules: add dropped defines to work with 5.9+
+Subject: [PATCH 02/20] kernel-modules: add dropped defines to work with 5.9+
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -24,5 +24,5 @@ index 1410294944eb..0b2dab92fda4 100644
  /* Helper defines for multi-version kernel  support */
  #if LINUX_VERSION_CODE < KERNEL_VERSION(2,5,0)
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch
@@ -1,7 +1,7 @@
 From eb4c8fcd136a3c85bff58b7c98f9ade923db98e3 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 15:54:54 +0100
-Subject: [PATCH 03/19] linux-kernel-bde: update API usage for 5.10
+Subject: [PATCH 03/20] linux-kernel-bde: update API usage for 5.10
 
 ---
  sdk-6.5.24/systems/bde/linux/include/linux_dma.h          | 2 +-
@@ -58,5 +58,5 @@ index 7628fd92c414..141bd53dade6 100644
  #define HX5_IHOST_GICD_ISENABLERN_0        (0x10781100)
  #define HX5_IHOST_GICD_ISENABLERN_1        (0x10781104)
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0004-bcm-knet-update-API-for-linux-5.6.0.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0004-bcm-knet-update-API-for-linux-5.6.0.patch
@@ -1,7 +1,7 @@
 From 6edc6d41bf3f5a3cde6547c4827c40e745dc0f6f Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 18 Nov 2022 16:12:08 +0100
-Subject: [PATCH 04/19] bcm-knet: update API for linux 5.6.0
+Subject: [PATCH 04/20] bcm-knet: update API for linux 5.6.0
 
 ---
  .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 71 ++++++++++++++++++-
@@ -181,5 +181,5 @@ index 025c6d759840..b701c38c2027 100755
  static int
  bkn_proc_init(void)
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch
@@ -1,7 +1,7 @@
 From bf2dda4bfe2a12d121e97f4875f15ef34b6d8ec0 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 4 Feb 2022 12:34:02 +0100
-Subject: [PATCH 05/19] bcm-knet: strip vlan tag if received untagged at port
+Subject: [PATCH 05/20] bcm-knet: strip vlan tag if received untagged at port
 
 The CPU port will always add a vlan tag, but we can check the header for
 the state at reception. If it was received untagged, strip the vlan tag
@@ -202,5 +202,5 @@ index b701c38c2027..10d08f798ab0 100755
                          rx_cb_meta = sand_scratch_data;
                      } else {
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0006-bcm-knet-report-link-state.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0006-bcm-knet-report-link-state.patch
@@ -1,7 +1,7 @@
 From 3a9f1b8a791e5dc139eb53410bc2f26ecef76211 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 12:11:54 +0100
-Subject: [PATCH 06/19] bcm-knet: report link state
+Subject: [PATCH 06/20] bcm-knet: report link state
 
 We set netif carrier, so we can just use ethtool_op_get_link.
 
@@ -23,5 +23,5 @@ index 10d08f798ab0..e03de2b76fa3 100755
      .get_ts_info        = bkn_get_ts_info,
  #endif
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0007-bcm-knet-allow-setting-speed-duplex.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0007-bcm-knet-allow-setting-speed-duplex.patch
@@ -1,7 +1,7 @@
 From 8b7522199a3e718dcecf55f8dd361a07ce435ff2 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 14:28:11 +0100
-Subject: [PATCH 07/19] bcm-knet: allow setting speed/duplex
+Subject: [PATCH 07/20] bcm-knet: allow setting speed/duplex
 
 To allow better emulation of physical port devices, extend the link
 state settings to also include link speed and duplex.
@@ -115,5 +115,5 @@ index e03de2b76fa3..eecd60db14e8 100755
              spin_unlock_irqrestore(&sinfo->lock, flags);
              return count;
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0008-bcm-knet-implement-get_link_ksettings.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0008-bcm-knet-implement-get_link_ksettings.patch
@@ -1,7 +1,7 @@
 From c6fa657413487f9957f9f3bbdfe944af934318e4 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 14:35:49 +0100
-Subject: [PATCH 08/19] bcm-knet: implement get_link_ksettings
+Subject: [PATCH 08/20] bcm-knet: implement get_link_ksettings
 
 To allow programs like ethtool access to the link speed, implement the
 get_link_ksettings callback.
@@ -66,5 +66,5 @@ index eecd60db14e8..681328485583 100755
      .get_ts_info        = bkn_get_ts_info,
  #endif
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0009-bcm-knet-fix-race-between-creation-and-open.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0009-bcm-knet-fix-race-between-creation-and-open.patch
@@ -1,7 +1,7 @@
 From 66b1242a93d5e05d34e77d7c0ddbe06eaf635a2e Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 20 Apr 2022 16:35:24 +0200
-Subject: [PATCH 09/19] bcm-knet: fix race between creation and open
+Subject: [PATCH 09/20] bcm-knet: fix race between creation and open
 
 When creating a netif, the netif will be registered and made available
 to userspace before its private data is initialized.
@@ -89,5 +89,5 @@ index 681328485583..9b347a6fe928 100755
          netif_napi_add(dev, &sinfo->napi, bkn_poll, napi_weight);
      }
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch
@@ -1,7 +1,7 @@
 From 70c844eb9889a4da8e6f7449cbbd88a0bb102d22 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 25 Apr 2022 10:48:26 +0200
-Subject: [PATCH 10/19] bcm-knet: use fully randomized mac addresses
+Subject: [PATCH 10/20] bcm-knet: use fully randomized mac addresses
 
 Instead of using partially randomized mac addresses with a Broadcom OUI
 prefix, use fully randomized mac addresses for generated virtualized
@@ -60,5 +60,5 @@ index 9b347a6fe928..329f1066a511 100755
          return sizeof(kcom_msg_hdr_t);
      }
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch
@@ -1,7 +1,7 @@
 From 535f8430806f374b800c89da04c42c74d00a407d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 26 Sep 2022 10:34:45 +0200
-Subject: [PATCH 11/19] bcm-knet: allow marking packets as offloaded
+Subject: [PATCH 11/20] bcm-knet: allow marking packets as offloaded
 
 When using KNET interfaces in a bridge, Linux will flood or forward any
 packets it sees according to default rules. This can be undesirable when
@@ -95,5 +95,5 @@ index 329f1066a511..dd36bd125865 100755
                      gprintk("Warning: unknown link state setting: '%s'\n", ptr);
                  }
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0012-bcm-knet-replace-open-coded-mac-change-code-with-eth.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0012-bcm-knet-replace-open-coded-mac-change-code-with-eth.patch
@@ -1,7 +1,7 @@
 From 754d1b1517b9f211172770aa309e1dd048f97c2b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 18 Nov 2022 16:24:41 +0100
-Subject: [PATCH 12/19] bcm-knet: replace open coded mac change code with
+Subject: [PATCH 12/20] bcm-knet: replace open coded mac change code with
  eth_mac_addr
 
 Linux 5.17 made netdev->dev_addr[] constant, so we cannot modify it
@@ -60,5 +60,5 @@ index dd36bd125865..3abacd4a1f1e 100755
      dev->open = bkn_open;
      dev->hard_start_xmit = bkn_tx;
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0013-bcm-knet-update-API-for-kernel-5.19.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0013-bcm-knet-update-API-for-kernel-5.19.patch
@@ -1,7 +1,7 @@
 From e114448356ffdeeb6836de5f3ff0090c048bfded Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 18 Nov 2022 16:46:01 +0100
-Subject: [PATCH 13/19] bcm-knet: update API for kernel 5.19
+Subject: [PATCH 13/20] bcm-knet: update API for kernel 5.19
 
 Update kernel API usage for 5.18 and 5.19:
 
@@ -59,5 +59,5 @@ index 3abacd4a1f1e..d8e14f9da5c8 100755
      return 0;
  }
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0014-linux-kernel-bde-use-platform_get_irq.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0014-linux-kernel-bde-use-platform_get_irq.patch
@@ -1,7 +1,7 @@
 From 47dd8fdad6aa4d644c4358506130cecad2eb266a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 21 Nov 2022 12:01:36 +0100
-Subject: [PATCH 14/19] linux-kernel-bde: use platform_get_irq()
+Subject: [PATCH 14/20] linux-kernel-bde: use platform_get_irq()
 
 The Kernel stopped providing platform resources for IRQs of device tree
 backed platform devices[1], and instead requires calling
@@ -41,5 +41,5 @@ index 1c778e5be06b..65d2b1aee410 100644
  
      ctrl->isr = NULL;
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0015-bcm-knet-extract-and-update-DSCP-for-IP-packets.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0015-bcm-knet-extract-and-update-DSCP-for-IP-packets.patch
@@ -1,7 +1,7 @@
 From 35a5b11b6a3e79488c9278454a410bffe81e6b66 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 6 May 2024 11:25:49 +0200
-Subject: [PATCH 15/19] bcm-knet: extract and update DSCP for IP packets
+Subject: [PATCH 15/20] bcm-knet: extract and update DSCP for IP packets
 
 For currently unknown reasons the Broadcom ASIC does not update the DSCP
 field for packets sent to controller. But the DMA header does have the
@@ -122,5 +122,5 @@ index d8e14f9da5c8..7834cdb29852 100755
                          rx_cb_meta = sand_scratch_data;
                      } else {
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0016-bcm-knet-fix-reported-tx-bytes.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0016-bcm-knet-fix-reported-tx-bytes.patch
@@ -1,7 +1,7 @@
 From abbde684f9f07dcc932ef89833291fdb05727f47 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 14 May 2025 15:47:49 +0200
-Subject: [PATCH 16/19] bcm-knet: fix reported tx bytes
+Subject: [PATCH 16/20] bcm-knet: fix reported tx bytes
 
 Do not include FCS and custom data header in tx byte counts. The custom
 header is never transmitted on the wire and consumed by the ASIC, so we
@@ -29,5 +29,5 @@ index 7834cdb29852..0dac8ec479d9 100755
      } else {
          DBG_VERB(("Tx busy: No DMA resources\n"));
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0017-bcm-knet-switch-to-stat64.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0017-bcm-knet-switch-to-stat64.patch
@@ -1,7 +1,7 @@
 From e955bc42216610a7f6b172c8b6036d286d180a3f Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 14 May 2025 10:48:41 +0200
-Subject: [PATCH 17/19] bcm-knet: switch to stat64
+Subject: [PATCH 17/20] bcm-knet: switch to stat64
 
 In preparation to report accurate counts, switch to stat64. This has no
 effect on 64 bit, but for 32 bit this switches to 64 bit counters. Since
@@ -391,5 +391,5 @@ index 0dac8ec479d9..0c2b6c5fa65b 100755
  
      DBG_VERB(("Created Ethernet device %s.\n", dev->name));
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0018-kcom-add-a-message-for-pushing-hw-counters-to-netifs.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0018-kcom-add-a-message-for-pushing-hw-counters-to-netifs.patch
@@ -1,7 +1,7 @@
 From 63cff5d34b4a27c1aeb7c45d4a9e75b0cfb4e536 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 15 May 2025 11:39:24 +0200
-Subject: [PATCH 18/19] kcom: add a message for pushing hw counters to netifs
+Subject: [PATCH 18/20] kcom: add a message for pushing hw counters to netifs
 
 In order to expose hw counters directly on knet interfaces, add a
 message to push them out.
@@ -83,5 +83,5 @@ index 028a2c771a4e..07a0618154ac 100755
  
  /*
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0019-bcm-knet-expose-hw-counters-on-port-netifs.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0019-bcm-knet-expose-hw-counters-on-port-netifs.patch
@@ -1,7 +1,7 @@
 From a1469e8668746b1382a4b045844c3eeae88fbff2 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 15 May 2025 11:56:06 +0200
-Subject: [PATCH 19/19] bcm-knet: expose hw counters on port netifs
+Subject: [PATCH 19/20] bcm-knet: expose hw counters on port netifs
 
 Now that we can we have a message for updating hw counters on netifs,
 handle in in the kernel driver and expose them as regular stats on port
@@ -241,5 +241,5 @@ index 0c2b6c5fa65b..6da8262aeca0 100755
          DBG_WARN(("Unsupported command (type=%d, opcode=%d)\n",
                    kmsg->hdr.type, kmsg->hdr.opcode));
 -- 
-2.49.0
+2.50.1
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0020-bcm-knet-do-not-mark-BPDU-packets-as-offloaded.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0020-bcm-knet-do-not-mark-BPDU-packets-as-offloaded.patch
@@ -1,0 +1,88 @@
+From 6bdeca9e704ff4a48318601f2a48ad589ef9dbbf Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Wed, 23 Apr 2025 14:37:20 +0200
+Subject: [PATCH 20/20] bcm-knet: do not mark BPDU packets as offloaded
+
+BPDU packets are trapped to controller and never forwarded, so do not
+mark them as offloaded. This allows them to be forwarded/flooded in
+software if needed.
+
+Note that this requires configuring the switch ASIC to mark traffic as
+BPDU via appropriate L2 cache entries, and there is no inherent
+automatic classification.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 42 ++++++++++++++++++-
+ 1 file changed, 40 insertions(+), 2 deletions(-)
+
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+index 6da8262aeca0..e3728c73a7d7 100755
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+@@ -2186,6 +2186,42 @@ bkn_pkt_is_rx_untagged(bkn_switch_info_t *sinfo, uint32_t *meta)
+     }
+ }
+ 
++
++#ifdef CONFIG_NET_SWITCHDEV
++
++#define DCB23_T13_BPDU  (1u << 17)
++#define DCB28_T6_BPDU   (1u << 30)
++#define DCB36_T11_BPDU  (1u << 0)
++
++static inline int
++bkn_pkt_was_switched(bkn_switch_info_t *sinfo, uint32_t *meta)
++{
++    /* BPDU packets are never switched */
++    switch (sinfo->dcb_type) {
++    case 28:
++         /* DPP */
++        return (meta[6] & DCB28_T6_BPDU) == 0;
++    case 23:
++    case 24:
++    case 26:
++    case 29:
++    case 31:
++    case 32:
++    case 34:
++    case 35:
++    case 37:
++         /* Triumph3 and newer */
++        return (meta[13] & DCB23_T13_BPDU) == 0;
++    case 36:
++        /* Trident 3 */
++        return (meta[11] & DCB36_T11_BPDU) == 0;
++    default:
++        /* currently unhandled */
++        return 1;
++    }
++}
++#endif
++
+ static inline uint8_t
+ bkn_pkt_new_dscp(bkn_switch_info_t *sinfo, uint32_t *meta)
+ {
+@@ -4082,7 +4118,8 @@ bkn_do_api_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+                     DBG_DUNE(("skb protocol 0x%04x\n", skb->protocol));
+ 
+ #ifdef CONFIG_NET_SWITCHDEV
+-		    skb->offload_fwd_mark = priv->offload_fwd_mark;
++                    if (priv->offload_fwd_mark)
++                        skb->offload_fwd_mark = bkn_pkt_was_switched(sinfo, meta);
+ #endif
+                     /*
+                      * Disable configuration API while the spinlock is released.
+@@ -4525,7 +4562,8 @@ bkn_do_skb_rx(bkn_switch_info_t *sinfo, int chan, int budget)
+                     }
+ 
+ #ifdef CONFIG_NET_SWITCHDEV
+-		    skb->offload_fwd_mark = priv->offload_fwd_mark;
++                    if (priv->offload_fwd_mark)
++                        skb->offload_fwd_mark = bkn_pkt_was_switched(sinfo, meta);
+ #endif
+                     if (mirror_local) {
+                         if (mskb) {
+-- 
+2.50.1
+

--- a/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
+++ b/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
@@ -31,6 +31,7 @@ SRC_URI = " \
           file://patches/0017-bcm-knet-switch-to-stat64.patch;striplevel=2 \
           file://patches/0018-kcom-add-a-message-for-pushing-hw-counters-to-netifs.patch;striplevel=2 \
           file://patches/0019-bcm-knet-expose-hw-counters-on-port-netifs.patch;striplevel=2 \
+          file://patches/0020-bcm-knet-do-not-mark-BPDU-packets-as-offloaded.patch;striplevel=2 \
           "
 
 SRC_URI:append:agema-ag7648 = " \


### PR DESCRIPTION
BPDU packets are trapped to controller and never forwarded, so do not mark them as offloaded. This allows them to be forwarded/flooded in software if needed.

Note that this requires configuring the switch ASIC to mark traffic as BPDU via appropriate L2 cache entries, and there is no inherent automatic classification.