### PR TITLE
ofdpa: allow creating termination MAC entries for local multicast traffic

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -1,9 +1,9 @@
 DESCRIPTION = ""
 LICENSE = "CLOSED"
 
-PR = "r44"
+PR = "r45"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "4cbd127fbbf22a234590870fb64cf4bb4b92df99"
+SRCREV_ofdpa = "3b95ff9fa02deb992ae9caabea0be29d1a2fc720"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
Currently we handle local multicast traffic via ACL rules. This has two unwanted side effects:

* Traffic that would have been dropped otherwise is still counted as dropped
* Traffic that would have been forwarded otherwise is still counted as forwarded

To fix this, make use of the ability of creating "BPDU" L2 cache entries in the switch ASIC.

These entries are never forwarded, do not count as dropped, and enable the BPDU bit in packet headers then available for KNET.

The closes equivalent to these entries are Termination MAC entries, which already use L2 cache entries if L2 station entries are not available. So create a new "classification" for Termination MAC entries that are treated as BPDU:

* EtherType matched is ETH_P_ALL (0x0003)
* MAC address matched is in the range 01:80:2c:* or 09:00:2b:*
* Goto Table is 0 (since they won't be forwarded)