### PR TITLE
ofdpa: fix deletion of BPDU termination MAC flows

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -1,9 +1,9 @@
 DESCRIPTION = ""
 LICENSE = "CLOSED"
 
-PR = "r45"
+PR = "r46"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "3b95ff9fa02deb992ae9caabea0be29d1a2fc720"
+SRCREV_ofdpa = "dc2b4c064df6808cd77df0fb3aed61da710431d8"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
Like creating BPDU termination MAC flows need to be delegated to the L2 cache entries, deleting them must also be delegated as well.

So forward the deletion request to driverTermMacEntryL2Delete() if the flags are empty (which they will only be for BPDU flows.

Before:

```
$ sudo client_cfg_purge
Purging flow tables.
        No entries found in tableId 210
        ...
        No entries found in tableId 17
        Error returned from ofdpaFlowDelete: rc = -27, tableId = 20
        Error returned from ofdpaFlowDelete: rc = -27, tableId = 20
        Error returned from ofdpaFlowDelete: rc = -27, tableId = 20
        Deleted 3 flows from tableId 20
        No entries found in tableId 24
        ...
$ client_flowtable_dump
No flow entries found.
$ sudo client_drivshell l2 cache show
  509 : mac=09:00:2b:00:00:04/ff:ff:ff:ff:ff:fe vlan=0/0x000 modid=0 port=0/cpu0 BPDU CPU lookup_class =0
  510 : mac=01:80:c2:00:00:14/ff:ff:ff:ff:ff:fe vlan=0/0x000 modid=0 port=0/cpu0 BPDU CPU lookup_class =0
  511 : mac=01:80:c2:00:00:00/ff:ff:ff:ff:ff:f0 vlan=0/0x000 modid=0 port=0/cpu0 BPDU CPU lookup_class =0
$
```

After:

```
$ sudo client_cfg_purge
Purging flow tables.
        No entries found in tableId 210
        ...
        No entries found in tableId 17
        Deleted 3 flows from tableId 20
        No entries found in tableId 24
        ...
$ client_flowtable_dump
No flow entries found.
$ sudo client_drivshell l2 cache show
$
```