### PR TITLE
openbcm-gpl-modules: add support for SDK tracked linkstate

### DIFF
--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0001-gmodule-update-proc-code-for-linux-5.6.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0001-gmodule-update-proc-code-for-linux-5.6.patch
@@ -1,7 +1,7 @@
-From 927503cbc4e0859bcda1f0c6964bffe5ec41a904 Mon Sep 17 00:00:00 2001
+From 0083d64b5170fd463e65a559584c7f274e0ca0db Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 15:55:39 +0100
-Subject: [PATCH 01/22] gmodule: update proc code for linux 5.6+
+Subject: [PATCH 01/24] gmodule: update proc code for linux 5.6+
 
 ---
  .../systems/linux/kernel/modules/shared/gmodule.c      | 10 ++++++++++

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0002-kernel-modules-add-dropped-defines-to-work-with-5.9.patch
@@ -1,7 +1,7 @@
-From f232ce3b07ba1de9ca50931fedf07bb7c8762824 Mon Sep 17 00:00:00 2001
+From ae64dfab1ee3aad9136c81577f9cc61fc6ced45d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 16:02:44 +0100
-Subject: [PATCH 02/22] kernel-modules: add dropped defines to work with 5.9+
+Subject: [PATCH 02/24] kernel-modules: add dropped defines to work with 5.9+
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0003-linux-kernel-bde-update-API-usage-for-5.10.patch
@@ -1,7 +1,7 @@
-From 3b7a997fd77dc63fdff25736983edbc27ffbb7c3 Mon Sep 17 00:00:00 2001
+From 94cb5fc4360b6e3aca4c6a490640f1ee15240aa9 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 14 Dec 2020 15:54:54 +0100
-Subject: [PATCH 03/22] linux-kernel-bde: update API usage for 5.10
+Subject: [PATCH 03/24] linux-kernel-bde: update API usage for 5.10
 
 ---
  sdk-6.5.24/systems/bde/linux/include/linux_dma.h          | 2 +-

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0004-bcm-knet-update-API-for-linux-5.6.0.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0004-bcm-knet-update-API-for-linux-5.6.0.patch
@@ -1,7 +1,7 @@
-From 305646bb718fb3186ee7236d86e0b2de400189d1 Mon Sep 17 00:00:00 2001
+From fc3227578b65ea8bb826d61f063d9382848e936b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 18 Nov 2022 16:12:08 +0100
-Subject: [PATCH 04/22] bcm-knet: update API for linux 5.6.0
+Subject: [PATCH 04/24] bcm-knet: update API for linux 5.6.0
 
 ---
  .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 71 ++++++++++++++++++-

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0005-bcm-knet-strip-vlan-tag-if-received-untagged-at-port.patch
@@ -1,7 +1,7 @@
-From 38c914a017f485c046349351dd464880ddf27d31 Mon Sep 17 00:00:00 2001
+From 197e6475b672b801b9223e04ac79e8c6863519a9 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 4 Feb 2022 12:34:02 +0100
-Subject: [PATCH 05/22] bcm-knet: strip vlan tag if received untagged at port
+Subject: [PATCH 05/24] bcm-knet: strip vlan tag if received untagged at port
 
 The CPU port will always add a vlan tag, but we can check the header for
 the state at reception. If it was received untagged, strip the vlan tag

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0006-bcm-knet-report-link-state.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0006-bcm-knet-report-link-state.patch
@@ -1,7 +1,7 @@
-From 50bc3b0c3c8087c84535624b8511838b8607d8fe Mon Sep 17 00:00:00 2001
+From 51ab65b7da8c0c7e3bc07ee5b1d1eb1a256061ac Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 12:11:54 +0100
-Subject: [PATCH 06/22] bcm-knet: report link state
+Subject: [PATCH 06/24] bcm-knet: report link state
 
 We set netif carrier, so we can just use ethtool_op_get_link.
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0007-bcm-knet-allow-setting-speed-duplex.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0007-bcm-knet-allow-setting-speed-duplex.patch
@@ -1,7 +1,7 @@
-From 06df0560e09f9c4bf932e365c8c43f742ac63543 Mon Sep 17 00:00:00 2001
+From 90ac22309ffefc514c5db52efb2043c1e16d1464 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 14:28:11 +0100
-Subject: [PATCH 07/22] bcm-knet: allow setting speed/duplex
+Subject: [PATCH 07/24] bcm-knet: allow setting speed/duplex
 
 To allow better emulation of physical port devices, extend the link
 state settings to also include link speed and duplex.

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0008-bcm-knet-implement-get_link_ksettings.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0008-bcm-knet-implement-get_link_ksettings.patch
@@ -1,7 +1,7 @@
-From 744e865db52e90818cf4b67cee8edb59946ca828 Mon Sep 17 00:00:00 2001
+From bff0e5ba2b2ace8ddae4c6273a2249967b18829d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 7 Feb 2022 14:35:49 +0100
-Subject: [PATCH 08/22] bcm-knet: implement get_link_ksettings
+Subject: [PATCH 08/24] bcm-knet: implement get_link_ksettings
 
 To allow programs like ethtool access to the link speed, implement the
 get_link_ksettings callback.

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0009-bcm-knet-fix-race-between-creation-and-open.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0009-bcm-knet-fix-race-between-creation-and-open.patch
@@ -1,7 +1,7 @@
-From 6cc0d7484e68c4dc32a1ec274402c04594cd7688 Mon Sep 17 00:00:00 2001
+From 52c44e080376c540c88c6a8e3f805a66c793f904 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 20 Apr 2022 16:35:24 +0200
-Subject: [PATCH 09/22] bcm-knet: fix race between creation and open
+Subject: [PATCH 09/24] bcm-knet: fix race between creation and open
 
 When creating a netif, the netif will be registered and made available
 to userspace before its private data is initialized.

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0010-bcm-knet-use-fully-randomized-mac-addresses.patch
@@ -1,7 +1,7 @@
-From 8eab43105606c6df887586de8f5149049c3ffbf4 Mon Sep 17 00:00:00 2001
+From 79079d55b6f8cca9ce410bf52f3598e0a8b134a0 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 25 Apr 2022 10:48:26 +0200
-Subject: [PATCH 10/22] bcm-knet: use fully randomized mac addresses
+Subject: [PATCH 10/24] bcm-knet: use fully randomized mac addresses
 
 Instead of using partially randomized mac addresses with a Broadcom OUI
 prefix, use fully randomized mac addresses for generated virtualized

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0011-bcm-knet-allow-marking-packets-as-offloaded.patch
@@ -1,7 +1,7 @@
-From 952a195467bf29b316fd065d86bcd58cd3f30d9f Mon Sep 17 00:00:00 2001
+From 970eb9faf4d877e95a0cecc83fa35dc938fd7d8a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 26 Sep 2022 10:34:45 +0200
-Subject: [PATCH 11/22] bcm-knet: allow marking packets as offloaded
+Subject: [PATCH 11/24] bcm-knet: allow marking packets as offloaded
 
 When using KNET interfaces in a bridge, Linux will flood or forward any
 packets it sees according to default rules. This can be undesirable when

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0012-bcm-knet-replace-open-coded-mac-change-code-with-eth.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0012-bcm-knet-replace-open-coded-mac-change-code-with-eth.patch
@@ -1,7 +1,7 @@
-From d20f48d8c7c403fab92957b55784e5ade94c2138 Mon Sep 17 00:00:00 2001
+From d08e3925c7cae121890b8710c86e43b4dc1454d2 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 18 Nov 2022 16:24:41 +0100
-Subject: [PATCH 12/22] bcm-knet: replace open coded mac change code with
+Subject: [PATCH 12/24] bcm-knet: replace open coded mac change code with
  eth_mac_addr
 
 Linux 5.17 made netdev->dev_addr[] constant, so we cannot modify it

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0013-bcm-knet-update-API-for-kernel-5.19.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0013-bcm-knet-update-API-for-kernel-5.19.patch
@@ -1,7 +1,7 @@
-From 7db35aad9d9de930aa846bbf45c5e1561d53e123 Mon Sep 17 00:00:00 2001
+From 529a2de7fd24ae0d27e0cceee29b76a6a5bac4e6 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 18 Nov 2022 16:46:01 +0100
-Subject: [PATCH 13/22] bcm-knet: update API for kernel 5.19
+Subject: [PATCH 13/24] bcm-knet: update API for kernel 5.19
 
 Update kernel API usage for 5.18 and 5.19:
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0014-linux-kernel-bde-use-platform_get_irq.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0014-linux-kernel-bde-use-platform_get_irq.patch
@@ -1,7 +1,7 @@
-From f8b935742160a4ae6f532138c04df17b4a4bef57 Mon Sep 17 00:00:00 2001
+From 2c1ab1dab25abd202b87d72d08243998e19e6d29 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 21 Nov 2022 12:01:36 +0100
-Subject: [PATCH 14/22] linux-kernel-bde: use platform_get_irq()
+Subject: [PATCH 14/24] linux-kernel-bde: use platform_get_irq()
 
 The Kernel stopped providing platform resources for IRQs of device tree
 backed platform devices[1], and instead requires calling

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0015-bcm-knet-extract-and-update-DSCP-for-IP-packets.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0015-bcm-knet-extract-and-update-DSCP-for-IP-packets.patch
@@ -1,7 +1,7 @@
-From af29b8cf9d0f64af03b8434b3c5a078d4dc72acc Mon Sep 17 00:00:00 2001
+From 92db249f579e8544e47a4ef3fdb31e595d2cea2f Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 6 May 2024 11:25:49 +0200
-Subject: [PATCH 15/22] bcm-knet: extract and update DSCP for IP packets
+Subject: [PATCH 15/24] bcm-knet: extract and update DSCP for IP packets
 
 For currently unknown reasons the Broadcom ASIC does not update the DSCP
 field for packets sent to controller. But the DMA header does have the

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0016-bcm-knet-fix-reported-tx-bytes.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0016-bcm-knet-fix-reported-tx-bytes.patch
@@ -1,7 +1,7 @@
-From ab8b2cee520fa95fcea036115221cac201e1ae79 Mon Sep 17 00:00:00 2001
+From 4219a47098b0ad66432f17726af511c06e4c4d85 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 14 May 2025 15:47:49 +0200
-Subject: [PATCH 16/22] bcm-knet: fix reported tx bytes
+Subject: [PATCH 16/24] bcm-knet: fix reported tx bytes
 
 Do not include FCS and custom data header in tx byte counts. The custom
 header is never transmitted on the wire and consumed by the ASIC, so we

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0017-bcm-knet-switch-to-stat64.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0017-bcm-knet-switch-to-stat64.patch
@@ -1,7 +1,7 @@
-From b0512e127bb503cb52d3eeefc03ea78f5151e682 Mon Sep 17 00:00:00 2001
+From 406c9e3d085759def362964ee5f7279ab79950c0 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 14 May 2025 10:48:41 +0200
-Subject: [PATCH 17/22] bcm-knet: switch to stat64
+Subject: [PATCH 17/24] bcm-knet: switch to stat64
 
 In preparation to report accurate counts, switch to stat64. This has no
 effect on 64 bit, but for 32 bit this switches to 64 bit counters. Since

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0018-kcom-add-a-message-for-pushing-hw-counters-to-netifs.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0018-kcom-add-a-message-for-pushing-hw-counters-to-netifs.patch
@@ -1,7 +1,7 @@
-From 34848c5689905f7be8b606c0bd6d4958707c0f23 Mon Sep 17 00:00:00 2001
+From d8e8f67e9aba7da38e19be88127f97a66dcca4f5 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 15 May 2025 11:39:24 +0200
-Subject: [PATCH 18/22] kcom: add a message for pushing hw counters to netifs
+Subject: [PATCH 18/24] kcom: add a message for pushing hw counters to netifs
 
 In order to expose hw counters directly on knet interfaces, add a
 message to push them out.

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0019-bcm-knet-expose-hw-counters-on-port-netifs.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0019-bcm-knet-expose-hw-counters-on-port-netifs.patch
@@ -1,7 +1,7 @@
-From 4b8499b20a4d1153e1ec1ef0bef7a236d4dee647 Mon Sep 17 00:00:00 2001
+From 2d976703d2043381fd6187998d03c71b714204cf Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 15 May 2025 11:56:06 +0200
-Subject: [PATCH 19/22] bcm-knet: expose hw counters on port netifs
+Subject: [PATCH 19/24] bcm-knet: expose hw counters on port netifs
 
 Now that we can we have a message for updating hw counters on netifs,
 handle in in the kernel driver and expose them as regular stats on port

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0020-bcm-knet-do-not-mark-BPDU-packets-as-offloaded.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0020-bcm-knet-do-not-mark-BPDU-packets-as-offloaded.patch
@@ -1,7 +1,7 @@
-From 48d8279f21ec06ba55ee63ea78dc560f8ec7b0bb Mon Sep 17 00:00:00 2001
+From f5fcfa873b4411f006da3245fa65ef3158f361b6 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 23 Apr 2025 14:37:20 +0200
-Subject: [PATCH 20/22] bcm-knet: do not mark BPDU packets as offloaded
+Subject: [PATCH 20/24] bcm-knet: do not mark BPDU packets as offloaded
 
 BPDU packets are trapped to controller and never forwarded, so do not
 mark them as offloaded. This allows them to be forwarded/flooded in

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0021-bde-handle-renamed-MAX_ORDER-in-linux-6.8.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0021-bde-handle-renamed-MAX_ORDER-in-linux-6.8.patch
@@ -1,9 +1,11 @@
-From 1d5458396a64f496418dfa5c5f5df2118b220368 Mon Sep 17 00:00:00 2001
+From 1e9d8d144f76193c4036fc2d00f1350b718d9194 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 18 Feb 2025 21:42:31 +0100
-Subject: [PATCH 21/22] bde: handle renamed MAX_ORDER in linux 6.8+
+Subject: [PATCH 21/24] bde: handle renamed MAX_ORDER in linux 6.8+
 
 MAX_ORDER was redefined and renamed as MAX_PAGE_ORDER in 6.8
+
+23baf831a32c04f9a968812511540b1b3e648bf5
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0022-bcm-knet-update-API-for-kernel-6.11.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0022-bcm-knet-update-API-for-kernel-6.11.patch
@@ -1,7 +1,7 @@
-From f8122b2a2e85acf5011ab4f53d43fe45f6cd9cb9 Mon Sep 17 00:00:00 2001
+From c2e055559ded2fdd51c15a6deb4367c2a1010bfd Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 18 Feb 2025 16:21:12 +0100
-Subject: [PATCH 22/22] bcm-knet: update API for kernel 6.11
+Subject: [PATCH 22/24] bcm-knet: update API for kernel 6.11
 
 Update kernel API usage for kernel 6.11:
 

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0023-kcom-add-link-state-message.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0023-kcom-add-link-state-message.patch
@@ -1,0 +1,85 @@
+From 558b596f4871555997c73a8bfacb9a07bfa5f1b3 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 10 Nov 2025 10:59:28 +0100
+Subject: [PATCH 23/24] kcom: add link state message
+
+Add a message for SDK to send link state to KNET interfaces.
+
+For now only support the basic attributes: link, speed, and duplex.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ sdk-6.5.24/include/kcom.h | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/sdk-6.5.24/include/kcom.h b/sdk-6.5.24/include/kcom.h
+index 07a0618154ac..b3b789b3e19f 100755
+--- a/sdk-6.5.24/include/kcom.h
++++ b/sdk-6.5.24/include/kcom.h
+@@ -51,6 +51,7 @@
+ #define KCOM_VERSION            13 /* Protocol version */
+ 
+ #define KCOM_M_NETIF_STATS	128 /* Netif stats */
++#define KCOM_M_NETIF_STATE      129 /* Netif link state */
+ 
+ /*
+  * Message status codes
+@@ -99,6 +100,9 @@ typedef struct kcom_msg_hdr_s {
+  *  KCOM_NETIF_F_RCPU_ENCAP
+  *  Use RCPU encapsulation for packets that enter and exit this
+  *  interface.
++ *
++ *  KCOM_NETIF_F_SDK_STATE
++ *  BISDN Extension: Link state is updated by SDK.
+  */
+ #define KCOM_NETIF_T_VLAN       0
+ #define KCOM_NETIF_T_PORT       1
+@@ -109,6 +113,8 @@ typedef struct kcom_msg_hdr_s {
+ /* If a netif has this flag, the packet sent to the netif can't be stripped tag or added tag */
+ #define KCOM_NETIF_F_KEEP_RX_TAG (1U << 2)
+ 
++#define KCOM_NETIF_F_SDK_STATE  (1U << 7)
++
+ #define KCOM_NETIF_NAME_MAX     16
+ 
+ /*
+@@ -369,6 +375,13 @@ typedef struct kcom_netif_stats_s {
+     uint64 dot3_late_collisions;
+ } kcom_netif_stats_t;
+ 
++typedef struct kcom_netif_state_s {
++    uint8 port;
++    uint8 link;
++    uint8 duplex;
++    uint32 speed;
++} kcom_netif_state_t;
++
+ /*
+  * Send literal string to/from kernel module.
+  * Mainly for debugging purposes.
+@@ -585,6 +598,14 @@ typedef struct kcom_msg_netif_stats_s {
+     kcom_netif_stats_t netif_stats;
+ } kcom_msg_netif_stats_t;
+ 
++/*
++ * Netif link state
++ */
++typedef struct kcom_msg_netif_state_s {
++    kcom_msg_hdr_t hdr;
++    kcom_netif_state_t netif_state;
++} kcom_msg_netif_state_t;
++
+ /*
+  * All messages (e.g. for generic receive)
+  */
+@@ -612,6 +633,7 @@ typedef union kcom_msg_s {
+     kcom_msg_wb_cleanup_t wb_cleanup;
+     kcom_msg_clock_cmd_t clock_cmd;
+     kcom_msg_netif_stats_t netif_stats;
++    kcom_msg_netif_state_t netif_state;
+ } kcom_msg_t;
+ 
+ /*
+-- 
+2.51.0
+

--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0024-bcm-knet-add-support-for-updating-link-state-in-kern.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0024-bcm-knet-add-support-for-updating-link-state-in-kern.patch
@@ -1,0 +1,129 @@
+From 81e5bac1ae14fa296cdd2670717127a15b210221 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 10 Nov 2025 11:19:13 +0100
+Subject: [PATCH 24/24] bcm-knet: add support for updating link state in kernel
+
+Add support for handling KCOM_M_NETIF_STATE messages and update any
+matching port interfaces on reception.
+
+Only update ports created with the flag KCOM_NETIF_F_SDK_STATE.
+
+For ports created with this flag, ignore any port state updates via the
+old interface.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../linux/kernel/modules/bcm-knet/bcm-knet.c  | 71 +++++++++++++++++--
+ 1 file changed, 66 insertions(+), 5 deletions(-)
+
+diff --git a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+index 429022b05f38..7992b6ff5f24 100755
+--- a/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
++++ b/sdk-6.5.24/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+@@ -7258,16 +7258,21 @@ bkn_proc_link_write(struct file *file, const char *buf,
+ 
+             while ((ptr = strsep(&tmp, ",")) != NULL) {
+                 if (strcmp(ptr, "up") == 0) {
+-                    netif_carrier_on(dev);
++                    if (!(priv->flags & KCOM_NETIF_F_SDK_STATE))
++                        netif_carrier_on(dev);
+                 } else if (strcmp(ptr, "down") == 0) {
+-                    netif_carrier_off(dev);
++                    if (!(priv->flags & KCOM_NETIF_F_SDK_STATE))
++                        netif_carrier_off(dev);
+                 } else if (strcmp(ptr, "fd") == 0) {
+-                    priv->duplex = DUPLEX_FULL;
++                    if (!(priv->flags & KCOM_NETIF_F_SDK_STATE))
++                        priv->duplex = DUPLEX_FULL;
+                 } else if (strcmp(ptr, "hd") == 0) {
+-                    priv->duplex = DUPLEX_HALF;
++                    if (!(priv->flags & KCOM_NETIF_F_SDK_STATE))
++                        priv->duplex = DUPLEX_HALF;
+                 } else if (sscanf(ptr, "%d", &speed) == 1 &&
+                            ethtool_validate_speed(speed) == 1) {
+-                    priv->speed = speed;
++                    if (!(priv->flags & KCOM_NETIF_F_SDK_STATE))
++                        priv->speed = speed;
+                 } else if (strcmp(ptr, "offload") == 0) {
+                     priv->offload_fwd_mark = 1;
+                 } else if (strcmp(ptr, "no-offload") == 0) {
+@@ -8910,6 +8915,13 @@ bkn_knet_netif_create(kcom_msg_netif_create_t *kmsg, int len)
+         kmsg->hdr.status = KCOM_E_PARAM;
+         return sizeof(kcom_msg_hdr_t);
+     }
++
++    if (kmsg->netif.type != KCOM_NETIF_T_PORT &&
++        (kmsg->netif.flags & KCOM_NETIF_F_SDK_STATE)) {
++        kmsg->hdr.status = KCOM_E_PARAM;
++        return sizeof(kcom_msg_hdr_t);
++    }
++
+     sinfo = bkn_sinfo_from_unit(kmsg->hdr.unit);
+     if (sinfo == NULL) {
+         kmsg->hdr.status = KCOM_E_PARAM;
+@@ -9529,6 +9541,50 @@ bkn_knet_netif_stats(kcom_msg_netif_stats_t *kmsg, int len)
+     return sizeof(kcom_msg_hdr_t);
+ }
+ 
++static int
++bkn_knet_netif_state(kcom_msg_netif_state_t *kmsg, int len)
++{
++    bkn_switch_info_t *sinfo;
++    struct list_head *list;
++    unsigned long flags;
++    bkn_priv_t *priv;
++
++    kmsg->hdr.type = KCOM_MSG_TYPE_RSP;
++
++    sinfo = bkn_sinfo_from_unit(kmsg->hdr.unit);
++    if (sinfo == NULL) {
++        kmsg->hdr.status = KCOM_E_PARAM;
++        return sizeof(kcom_msg_hdr_t);
++    }
++
++    spin_lock_irqsave(&sinfo->lock, flags);
++
++    list_for_each(list, &sinfo->ndev_list) {
++        priv = (bkn_priv_t *)list;
++
++        if (priv->type != KCOM_NETIF_T_PORT)
++            continue;
++
++        if (!(priv->flags & KCOM_NETIF_F_SDK_STATE))
++            continue;
++
++        if (priv->port != kmsg->netif_state.port)
++            continue;
++
++        if (kmsg->netif_state.link) {
++            priv->duplex = kmsg->netif_state.duplex;
++            priv->speed = kmsg->netif_state.speed;
++            netif_carrier_on(priv->dev);
++        } else {
++            netif_carrier_off(priv->dev);
++        }
++    }
++
++    spin_unlock_irqrestore(&sinfo->lock, flags);
++
++    return sizeof(kcom_msg_hdr_t);
++}
++
+ static int
+ bkn_handle_cmd_req(kcom_msg_t *kmsg, int len)
+ {
+@@ -9657,6 +9713,11 @@ bkn_handle_cmd_req(kcom_msg_t *kmsg, int len)
+         /* Update netif hardware counters */
+         len = bkn_knet_netif_stats(&kmsg->netif_stats, len);
+         break;
++     case KCOM_M_NETIF_STATE:
++        DBG_CMD(("KCOM_M_NETIF_STATE\n"));
++        /* Update netif link state */
++        len = bkn_knet_netif_state(&kmsg->netif_state, len);
++        break;
+     default:
+         DBG_WARN(("Unsupported command (type=%d, opcode=%d)\n",
+                   kmsg->hdr.type, kmsg->hdr.opcode));
+-- 
+2.51.0
+

--- a/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
+++ b/recipes-kernel/openbcm-gpl-modules/openbcm-gpl-modules_6.5.24.bb
@@ -34,6 +34,8 @@ SRC_URI = " \
           file://patches/0020-bcm-knet-do-not-mark-BPDU-packets-as-offloaded.patch;striplevel=2 \
           file://patches/0021-bde-handle-renamed-MAX_ORDER-in-linux-6.8.patch;striplevel=2 \
           file://patches/0022-bcm-knet-update-API-for-kernel-6.11.patch;striplevel=2 \
+          file://patches/0023-kcom-add-link-state-message.patch;striplevel=2 \
+          file://patches/0024-bcm-knet-add-support-for-updating-link-state-in-kern.patch;striplevel=2 \
           "
 
 SRC_URI:append:agema-ag7648 = " \


### PR DESCRIPTION
As a first step into allowing port configuration directly on the KNET interfaces, add support for updating linkstate by the SDK.

To do so, add a new flag for port interfaces to mark them as SDK managed, and add a new KNET message type for sending the link state to the kernel.

For any KNET interfaces wit hthe new flag set, updates via the old proc interface get silently ignored. This way no changes are necessary to baseboxd.

For now, only support link, speed, duplex, but in the future we can extend it with more attributes.