### PR TITLE
v5.x: suffix downloaded files with layerseries corename

### DIFF
--- a/recipes-extended/ofdpa-grpc/ofdpa-grpc.inc
+++ b/recipes-extended/ofdpa-grpc/ofdpa-grpc.inc
@@ -2,7 +2,7 @@
 BB_STRICT_CHECKSUM = "0"
 
 SRC_URI = " \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/${BPN}_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/${BPN}_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P};downloadfilename=${BPN}_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}_${LAYERSERIES_CORENAMES}.ipk \
 "
 
 # Manually calculate expanded ${SRCPV} value

--- a/recipes-ofdpa/ofdpa/ofdpa.inc
+++ b/recipes-ofdpa/ofdpa/ofdpa.inc
@@ -8,12 +8,12 @@ BB_STRICT_CHECKSUM = "0"
 # pulled in from
 # https://github.com/bisdn/meta-switch/blob/master/conf/distro/bisdn-linux.conf
 SRC_URI = " \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofagent_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa-firmware-bcm56370_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa-firmware-bcm56770_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa-firmware-bcm56870_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
- ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/python3-ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P} \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofagent_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P};downloadfilename=ofagent_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}_${LAYERSERIES_CORENAMES}.ipk \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P};downloadfilename=ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}_${LAYERSERIES_CORENAMES}.ipk \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa-firmware-bcm56370_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P};downloadfilename=ofdpa-firmware-bcm56370_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}_${LAYERSERIES_CORENAMES}.ipk \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa-firmware-bcm56770_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P};downloadfilename=ofdpa-firmware-bcm56770_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}_${LAYERSERIES_CORENAMES}.ipk \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/ofdpa-firmware-bcm56870_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P};downloadfilename=ofdpa-firmware-bcm56870_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}_${LAYERSERIES_CORENAMES}.ipk \
+ ${FEEDDOMAIN}/${FEEDURIPREFIX}/ipk/${PACKAGE_ARCH}/python3-ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}.ipk;subdir=${P};downloadfilename=python3-ofdpa_${@'${PV}'.replace('AUTOINC', '0')}-${PR}_${PACKAGE_ARCH}_${LAYERSERIES_CORENAMES}.ipk \
 "
 
 inherit bin_package


### PR DESCRIPTION
Packages built for different Yocto versions are often incompatible. When sharing a download directory between different trees, we may use the wrong .ipks for re-building the binary package, when the version matches with a different release.

Work around this by storing the layerseries codename (.e.g "scarthgap") in the downloaded filename, to make sure that it is unique per Yocto version.