### PR TITLE
ofdpa: add support for SDK tracked linkstate

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -1,9 +1,9 @@
 DESCRIPTION = ""
 LICENSE = "CLOSED"
 
-PR = "r49"
+PR = "r50"
 SDK_VERSION = "6.5.24"
-SRCREV_ofdpa = "2623c9a48b1842475d929883033683ef171dd177"
+SRCREV_ofdpa = "ba570cfc83750905c1ced4ef403d81e8d9620ee1"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
 
 inherit systemd python3-dir


### PR DESCRIPTION
As a first step into allowing port configuration directly on the KNET interfaces, add support for updating linkstate by the SDK.

To do so, add a new flag for port interfaces to mark them as SDK tracked, and add a new KNET message type for sending the link state to the kernel.

For any KNET interfaces with the new flag set, updates via the old proc interface get silently ignored. This way no changes are necessary to baseboxd.

Additionally, tracked KNET interfaces are limited to one per port. This allows us to store them in a lookup table without having to iterate the list of interfaces.

For now, only support link, speed, duplex, but in the future we can extend it with more attributes.