### PR TITLE
ofdpa: switch to external cjson library

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = ""
 LICENSE = "CLOSED"
 
-PR = "r50"
+PR = "r51"
 SDK_VERSION = "6.5.24"
 SRCREV_ofdpa = "ba570cfc83750905c1ced4ef403d81e8d9620ee1"
 SRCREV_sdk = "0b149ddfa3878e65eb217a11dddb999d3e205d03"
@@ -10,7 +10,7 @@ inherit systemd python3-dir
 
 include ofdpa.inc
 
-DEPENDS += "python3 onl"
+DEPENDS += "cjson python3 onl"
 
 RDEPENDS:${PN} += "libgcc udev openbcm-gpl-modules ofdpa-platform"
 


### PR DESCRIPTION
Drop our integrated copy of cJSON with the Yocto provided one that is actually maintained.