### PR TITLE
openbcm-gpl-modules: fix netifs lookup array size

### DIFF
--- a/recipes-kernel/openbcm-gpl-modules/files/patches/0023-KNET-add-base-support-for-tracked-interfaces.patch
+++ b/recipes-kernel/openbcm-gpl-modules/files/patches/0023-KNET-add-base-support-for-tracked-interfaces.patch
@@ -49,7 +49,7 @@ index 429022b05f38..9d84b6b67759 100755
          uint32_t pkts_d_no_api_buf; /* Rx drop - no API buffers */
      } rx[NUM_RX_CHAN];
 +
-+    void *netifs[KCOM_NETIF_MAX];
++    void *netifs[256];
  } bkn_switch_info_t;
  
  #define INVALID_INSTANCE_ID         BDE_DEV_INST_ID_INVALID


### PR DESCRIPTION
The physical port number used by KNET is not equivalent to the debug port number, and may exceed 128 (KCOM_NETIF_MAX). So increase the array size to accomodate all possible physical ports (which is 256).

Fixes: 36c5fc1220b0 ("openbcm-modules: update link state support")