### PR TITLE
ofagent: timebound processing queued tasks

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -3,7 +3,7 @@ LICENSE = "CLOSED"
 
 PR = "r1"
 SDK_VERSION = "6.5.24"
-SRCREV = "037784e28a748358ebe521cb12283e5d30eb2482"
+SRCREV = "2d95941db1295ad361868b5be0e5b75fb3e78a54"
 
 inherit systemd python3-dir
 


### PR DESCRIPTION
Each processed message can trigger a task, which will then get processed after processing all pending messages.

Processing the queued tasks can take a long time, in which no further messages will be processed. This can lead to incoming echo requests during not being serviced until all tasks are finished. On slower systems, this can mean that echo replies can take longer than the controller is willing to wait, breaking the connection.

Work around this by time bounding task processing to 10 timeslices, which is ~100ms by default. This ensures that any echo requests will be handled in a timely manner.

Note that if the stress situation where messages come in quicker than they can be processed persists, the queue may grow unbounded. We may want to add limits here in the future.