### PR TITLE
ofagent: don't send echo requests in barrier

### DIFF
--- a/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
+++ b/recipes-ofdpa/ofdpa/ofdpa_3.0.5.0-EA5.bb
@@ -3,7 +3,7 @@ LICENSE = "CLOSED"
 
 PR = "r1"
 SDK_VERSION = "6.5.24"
-SRCREV = "1436dcbdbbe41fb1aee27bfc1470e2cc32ff02d6"
+SRCREV = "d22c228ddd325e7943a8b1696006d38362bd5e03"
 
 inherit systemd python3-dir
 


### PR DESCRIPTION
While in barrier, we do not processes incoming messages, so we will never see any replies. Longrunning barriers can then easily trigger a connection error due to "no replies".

Work around this by not sending echo requests when in barrier.